### PR TITLE
Add missing YAML syntax highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ steps:
   - uses: cdsap/build-process-watcher/start@v0.1
     with:
       interval: 5
-  
+
   - run: ./gradlew build
-  
+
   - uses: cdsap/build-process-watcher/cleanup@v0.1
     if: always()
 ```

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ Use this if you want a clean setup:
 ## 🛠️ Manual Mode (Debug / Safe Cleanup)
 Use this if you want guaranteed cleanup, even if the build fails:
 steps:
-```
-  - uses: cdsap/build-process-watcher/start@v0.1
-    with:
-      interval: 5
+```yaml
+- uses: cdsap/build-process-watcher/start@v0.1
+  with:
+    interval: 5
 
-  - run: ./gradlew build
+- run: ./gradlew build
 
-  - uses: cdsap/build-process-watcher/cleanup@v0.1
-    if: always()
+- uses: cdsap/build-process-watcher/cleanup@v0.1
+  if: always()
 ```
 ✅ More verbose
 ✅ Ensures cleanup runs at the end of the job (unless the entire runner crashes)

--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ Use this if you want a clean setup:
 
 ## 🛠️ Manual Mode (Debug / Safe Cleanup)
 Use this if you want guaranteed cleanup, even if the build fails:
-steps:
+
 ```yaml
-- uses: cdsap/build-process-watcher/start@v0.1
-  with:
-    interval: 5
-
-- run: ./gradlew build
-
-- uses: cdsap/build-process-watcher/cleanup@v0.1
-  if: always()
+steps:
+  - uses: cdsap/build-process-watcher/start@v0.1
+    with:
+      interval: 5
+  
+  - run: ./gradlew build
+  
+  - uses: cdsap/build-process-watcher/cleanup@v0.1
+    if: always()
 ```
 ✅ More verbose
 ✅ Ensures cleanup runs at the end of the job (unless the entire runner crashes)


### PR DESCRIPTION
~And remove unnecessary indentation.~

Actually, it seems like the indentation was on purpose but the `steps:` was not at the right place. Fixed in https://github.com/cdsap/build-process-watcher/pull/1/commits/22a576f1e43d8359b45cf59143acf2c81d10260c