### PR TITLE
Add disable_summary_output option and change collect_gc default to true

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,10 @@ inputs:
   collect_gc:
     description: 'Enable garbage collection monitoring (requires Java processes)'
     required: false
+    default: 'true'
+  disable_summary_output:
+    description: 'Disable GitHub Actions summary output when remote monitoring is enabled (only applies when remote_monitoring is true)'
+    required: false
     default: 'false'
   environment:
     description: 'Environment name (production or staging) - used for auto-detecting default URLs'

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -214296,8 +214296,10 @@ async function run() {
                 }
             }
         }
-        // Add to GitHub Actions summary (always generated)
-        if (process.env.GITHUB_STEP_SUMMARY) {
+        // Add to GitHub Actions summary (only if not disabled for remote mode)
+        const disableSummaryOutput = process.env.DISABLE_SUMMARY_OUTPUT === 'true';
+        const shouldGenerateSummary = !(backendMode && disableSummaryOutput);
+        if (process.env.GITHUB_STEP_SUMMARY && shouldGenerateSummary) {
             const summary = fs.readFileSync(process.env.GITHUB_STEP_SUMMARY, 'utf8');
             if (backendMode && runId) {
                 // Remote monitoring mode - show dashboard info + Mermaid diagram if data available

--- a/dist/index_with_backend.js
+++ b/dist/index_with_backend.js
@@ -25694,7 +25694,10 @@ async function run() {
         const runId = core.getInput('run_id') || `run-${Date.now()}`;
         const logFile = core.getInput('log_file') || 'build_process_watcher.log';
         const debugMode = core.getInput('debug') === 'true';
-        const collectGc = core.getInput('collect_gc') === 'true';
+        // collect_gc defaults to 'true' - only disable if explicitly set to 'false'
+        const collectGcInput = core.getInput('collect_gc');
+        const collectGc = collectGcInput === '' || collectGcInput === 'true';
+        const disableSummaryOutput = core.getInput('disable_summary_output') === 'true';
         const environment = core.getInput('environment') || 'production'; // Default to production
         // If backend is enabled but no URL provided, use the default Cloud Run URL based on environment
         if (enableBackend && !backendUrl) {
@@ -25769,6 +25772,7 @@ async function run() {
         core.exportVariable('RUN_ID', runId);
         core.exportVariable('LOG_FILE', logFile);
         core.exportVariable('ENVIRONMENT', environment);
+        core.exportVariable('DISABLE_SUMMARY_OUTPUT', disableSummaryOutput.toString());
         if (frontendUrl) {
             // Extract base URL (without /runs/runId) for cleanup step
             const baseFrontendUrl = frontendUrl.replace(/\/runs\/.*$/, '');

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -641,8 +641,11 @@ async function run() {
             }
         }
 
-        // Add to GitHub Actions summary (always generated)
-        if (process.env.GITHUB_STEP_SUMMARY) {
+        // Add to GitHub Actions summary (only if not disabled for remote mode)
+        const disableSummaryOutput = process.env.DISABLE_SUMMARY_OUTPUT === 'true';
+        const shouldGenerateSummary = !(backendMode && disableSummaryOutput);
+        
+        if (process.env.GITHUB_STEP_SUMMARY && shouldGenerateSummary) {
             const summary = fs.readFileSync(process.env.GITHUB_STEP_SUMMARY, 'utf8');
 
             if (backendMode && runId) {

--- a/src/index_with_backend.ts
+++ b/src/index_with_backend.ts
@@ -11,7 +11,10 @@ async function run() {
     const runId = core.getInput('run_id') || `run-${Date.now()}`;
     const logFile = core.getInput('log_file') || 'build_process_watcher.log';
     const debugMode = core.getInput('debug') === 'true';
-    const collectGc = core.getInput('collect_gc') === 'true';
+    // collect_gc defaults to 'true' - only disable if explicitly set to 'false'
+    const collectGcInput = core.getInput('collect_gc');
+    const collectGc = collectGcInput === '' || collectGcInput === 'true';
+    const disableSummaryOutput = core.getInput('disable_summary_output') === 'true';
     const environment = core.getInput('environment') || 'production'; // Default to production
 
     // If backend is enabled but no URL provided, use the default Cloud Run URL based on environment
@@ -96,6 +99,7 @@ async function run() {
     core.exportVariable('RUN_ID', runId);
     core.exportVariable('LOG_FILE', logFile);
     core.exportVariable('ENVIRONMENT', environment);
+    core.exportVariable('DISABLE_SUMMARY_OUTPUT', disableSummaryOutput.toString());
     if (frontendUrl) {
       // Extract base URL (without /runs/runId) for cleanup step
       const baseFrontendUrl = frontendUrl.replace(/\/runs\/.*$/, '');


### PR DESCRIPTION
- Add disable_summary_output input to disable GitHub Actions summary when remote monitoring is enabled
- Change collect_gc default from 'false' to 'true' (can still be disabled explicitly)
- Update cleanup.ts to respect disable_summary_output flag for remote mode
- Update index_with_backend.ts to handle new defaults and export disable_summary_output flag