### PR TITLE
Add VM flags tracking per process

### DIFF
--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -1,0 +1,115 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cdsap/build-process-watcher/backend/internal/models"
+)
+
+func TestIngestHandler_RequestWithProcessInfo(t *testing.T) {
+	// Test that IngestRequest with ProcessInfo can be properly parsed
+	request := models.IngestRequest{
+		RunID: "test-run-123",
+		Data:  "00:00:01 | 12345 | GradleDaemon | 100MB | 200MB | 300MB",
+		ProcessInfo: &models.ProcessInfo{
+			PID:     "12345",
+			Name:    "GradleDaemon",
+			VMFlags: []string{"-XX:+UseG1GC", "-XX:MaxHeapSize=2g"},
+		},
+	}
+
+	jsonData, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("Failed to marshal request: %v", err)
+	}
+
+	// Verify it can be unmarshaled correctly
+	var unmarshaled models.IngestRequest
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal request: %v", err)
+	}
+
+	if unmarshaled.ProcessInfo == nil {
+		t.Fatal("ProcessInfo should not be nil")
+	}
+
+	if unmarshaled.ProcessInfo.PID != "12345" {
+		t.Errorf("PID mismatch: expected 12345, got %s", unmarshaled.ProcessInfo.PID)
+	}
+
+	if len(unmarshaled.ProcessInfo.VMFlags) != 2 {
+		t.Errorf("Expected 2 VM flags, got %d", len(unmarshaled.ProcessInfo.VMFlags))
+	}
+}
+
+func TestRunResponse_WithProcessInfo(t *testing.T) {
+	// Test that RunResponse correctly includes ProcessInfo
+	processInfo := make(map[string]models.ProcessInfo)
+	processInfo["12345"] = models.ProcessInfo{
+		PID:     "12345",
+		Name:    "GradleDaemon",
+		VMFlags: []string{"-XX:+UseG1GC", "-XX:MaxHeapSize=2g"},
+	}
+
+	response := models.RunResponse{
+		Samples:     []models.Sample{},
+		ProcessInfo: processInfo,
+		Finished:    false,
+	}
+
+	jsonData, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("Failed to marshal RunResponse: %v", err)
+	}
+
+	var unmarshaled models.RunResponse
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal RunResponse: %v", err)
+	}
+
+	if unmarshaled.ProcessInfo == nil {
+		t.Fatal("ProcessInfo should not be nil in response")
+	}
+
+	if len(unmarshaled.ProcessInfo) != 1 {
+		t.Errorf("Expected 1 process info entry, got %d", len(unmarshaled.ProcessInfo))
+	}
+
+	stored, ok := unmarshaled.ProcessInfo["12345"]
+	if !ok {
+		t.Fatal("Process info for PID 12345 not found in response")
+	}
+
+	if stored.PID != "12345" {
+		t.Errorf("PID mismatch: expected 12345, got %s", stored.PID)
+	}
+
+	if len(stored.VMFlags) != 2 {
+		t.Errorf("Expected 2 VM flags, got %d", len(stored.VMFlags))
+	}
+}
+
+func TestRunResponse_WithoutProcessInfo(t *testing.T) {
+	// Test that RunResponse works when ProcessInfo is nil
+	response := models.RunResponse{
+		Samples:     []models.Sample{},
+		ProcessInfo: nil,
+		Finished:    false,
+	}
+
+	jsonData, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("Failed to marshal RunResponse: %v", err)
+	}
+
+	var unmarshaled models.RunResponse
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal RunResponse: %v", err)
+	}
+
+	// ProcessInfo can be nil when not present
+	if unmarshaled.ProcessInfo != nil && len(unmarshaled.ProcessInfo) > 0 {
+		t.Error("ProcessInfo should be nil or empty when not present")
+	}
+}

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -15,27 +15,36 @@ type Sample struct {
 	RunID       string `firestore:"run_id"`
 }
 
+// ProcessInfo contains information about a specific process
+type ProcessInfo struct {
+	PID     string   `firestore:"pid"`
+	Name    string   `firestore:"name"`
+	VMFlags []string `firestore:"vm_flags"`
+}
+
 // RunDoc represents a monitoring run document in Firestore
 type RunDoc struct {
-	ID                 string    `firestore:"id"`
-	RunID              string    `firestore:"run_id"`
-	StartTime          time.Time `firestore:"start_time"`
-	EndTime            time.Time `firestore:"end_time,omitempty"`
-	CreatedAt          time.Time `firestore:"created_at"`
-	UpdatedAt          time.Time `firestore:"updated_at"`
-	UpdatedAtTimestamp int64     `firestore:"updated_at_timestamp"` // Unix millis for timezone-independent queries
-	Samples            []Sample  `firestore:"samples"`
-	Finished           bool      `firestore:"finished,omitempty"`
-	FinishedAt         time.Time `firestore:"finished_at,omitempty"`
-	ExpireAt           time.Time `firestore:"expire_at,omitempty"` // TTL field - set manually in Firestore, used by TTL policy
+	ID                 string                 `firestore:"id"`
+	RunID              string                 `firestore:"run_id"`
+	StartTime          time.Time              `firestore:"start_time"`
+	EndTime            time.Time              `firestore:"end_time,omitempty"`
+	CreatedAt          time.Time              `firestore:"created_at"`
+	UpdatedAt          time.Time              `firestore:"updated_at"`
+	UpdatedAtTimestamp int64                  `firestore:"updated_at_timestamp"` // Unix millis for timezone-independent queries
+	Samples            []Sample               `firestore:"samples"`
+	ProcessInfo        map[string]ProcessInfo `firestore:"process_info,omitempty"` // PID -> ProcessInfo map
+	Finished           bool                   `firestore:"finished,omitempty"`
+	FinishedAt         time.Time              `firestore:"finished_at,omitempty"`
+	ExpireAt           time.Time              `firestore:"expire_at,omitempty"` // TTL field - set manually in Firestore, used by TTL policy
 }
 
 // RunResponse is the API response for a run
 type RunResponse struct {
-	Samples    []Sample   `json:"samples"`
-	Finished   bool       `json:"finished"`
-	FinishedAt *time.Time `json:"finished_at,omitempty"`
-	UpdatedAt  time.Time  `json:"updated_at"`
+	Samples     []Sample               `json:"samples"`
+	ProcessInfo map[string]ProcessInfo `json:"process_info,omitempty"`
+	Finished    bool                   `json:"finished"`
+	FinishedAt  *time.Time             `json:"finished_at,omitempty"`
+	UpdatedAt   time.Time              `json:"updated_at"`
 }
 
 // TokenRequest is the request body for token generation
@@ -58,6 +67,7 @@ type TokenData struct {
 
 // IngestRequest is the request body for data ingestion
 type IngestRequest struct {
-	RunID string `json:"run_id"`
-	Data  string `json:"data"`
+	RunID       string       `json:"run_id"`
+	Data        string       `json:"data"`
+	ProcessInfo *ProcessInfo `json:"process_info,omitempty"` // Optional: VM flags for a new process
 }

--- a/backend/internal/models/models_test.go
+++ b/backend/internal/models/models_test.go
@@ -1,0 +1,219 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestProcessInfo_MarshalJSON(t *testing.T) {
+	processInfo := ProcessInfo{
+		PID:     "12345",
+		Name:    "GradleDaemon",
+		VMFlags: []string{"-XX:+UseG1GC", "-XX:MaxHeapSize=2g", "-XX:+UseCompressedOops"},
+	}
+
+	jsonData, err := json.Marshal(processInfo)
+	if err != nil {
+		t.Fatalf("Failed to marshal ProcessInfo: %v", err)
+	}
+
+	var unmarshaled ProcessInfo
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal ProcessInfo: %v", err)
+	}
+
+	if unmarshaled.PID != processInfo.PID {
+		t.Errorf("PID mismatch: expected %s, got %s", processInfo.PID, unmarshaled.PID)
+	}
+	if unmarshaled.Name != processInfo.Name {
+		t.Errorf("Name mismatch: expected %s, got %s", processInfo.Name, unmarshaled.Name)
+	}
+	if len(unmarshaled.VMFlags) != len(processInfo.VMFlags) {
+		t.Errorf("VMFlags length mismatch: expected %d, got %d", len(processInfo.VMFlags), len(unmarshaled.VMFlags))
+	}
+	for i, flag := range processInfo.VMFlags {
+		if i >= len(unmarshaled.VMFlags) || unmarshaled.VMFlags[i] != flag {
+			t.Errorf("VMFlags[%d] mismatch: expected %s, got %s", i, flag, func() string {
+				if i < len(unmarshaled.VMFlags) {
+					return unmarshaled.VMFlags[i]
+				}
+				return "<nil>"
+			}())
+		}
+	}
+}
+
+func TestProcessInfo_EmptyVMFlags(t *testing.T) {
+	processInfo := ProcessInfo{
+		PID:     "12345",
+		Name:    "GradleDaemon",
+		VMFlags: []string{},
+	}
+
+	jsonData, err := json.Marshal(processInfo)
+	if err != nil {
+		t.Fatalf("Failed to marshal ProcessInfo with empty VMFlags: %v", err)
+	}
+
+	var unmarshaled ProcessInfo
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal ProcessInfo with empty VMFlags: %v", err)
+	}
+
+	if len(unmarshaled.VMFlags) != 0 {
+		t.Errorf("Expected empty VMFlags, got %d flags", len(unmarshaled.VMFlags))
+	}
+}
+
+func TestProcessInfo_NilVMFlags(t *testing.T) {
+	processInfo := ProcessInfo{
+		PID:  "12345",
+		Name: "GradleDaemon",
+		// VMFlags is nil
+	}
+
+	jsonData, err := json.Marshal(processInfo)
+	if err != nil {
+		t.Fatalf("Failed to marshal ProcessInfo with nil VMFlags: %v", err)
+	}
+
+	var unmarshaled ProcessInfo
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal ProcessInfo with nil VMFlags: %v", err)
+	}
+
+	if unmarshaled.VMFlags == nil {
+		t.Log("VMFlags is nil (this is acceptable)")
+	}
+}
+
+func TestRunDoc_ProcessInfo(t *testing.T) {
+	runDoc := RunDoc{
+		ID:      "test-run",
+		RunID:   "test-run",
+		Samples: []Sample{},
+	}
+
+	// Test that ProcessInfo can be nil initially
+	if runDoc.ProcessInfo != nil {
+		t.Error("ProcessInfo should be nil initially")
+	}
+
+	// Initialize ProcessInfo map
+	runDoc.ProcessInfo = make(map[string]ProcessInfo)
+
+	// Add process info
+	processInfo := ProcessInfo{
+		PID:     "12345",
+		Name:    "GradleDaemon",
+		VMFlags: []string{"-XX:+UseG1GC"},
+	}
+	runDoc.ProcessInfo["12345"] = processInfo
+
+	if len(runDoc.ProcessInfo) != 1 {
+		t.Errorf("Expected 1 process info entry, got %d", len(runDoc.ProcessInfo))
+	}
+
+	stored, ok := runDoc.ProcessInfo["12345"]
+	if !ok {
+		t.Fatal("Process info for PID 12345 not found")
+	}
+
+	if stored.PID != processInfo.PID {
+		t.Errorf("Stored PID mismatch: expected %s, got %s", processInfo.PID, stored.PID)
+	}
+}
+
+func TestRunResponse_ProcessInfo(t *testing.T) {
+	response := RunResponse{
+		Samples:     []Sample{},
+		ProcessInfo: make(map[string]ProcessInfo),
+		Finished:    false,
+	}
+
+	// Add process info
+	processInfo := ProcessInfo{
+		PID:     "12345",
+		Name:    "GradleDaemon",
+		VMFlags: []string{"-XX:+UseG1GC", "-XX:MaxHeapSize=2g"},
+	}
+	response.ProcessInfo["12345"] = processInfo
+
+	// Marshal to JSON to verify it works
+	jsonData, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("Failed to marshal RunResponse: %v", err)
+	}
+
+	var unmarshaled RunResponse
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal RunResponse: %v", err)
+	}
+
+	if len(unmarshaled.ProcessInfo) != 1 {
+		t.Errorf("Expected 1 process info entry, got %d", len(unmarshaled.ProcessInfo))
+	}
+
+	stored, ok := unmarshaled.ProcessInfo["12345"]
+	if !ok {
+		t.Fatal("Process info for PID 12345 not found after unmarshal")
+	}
+
+	if stored.PID != processInfo.PID {
+		t.Errorf("Stored PID mismatch: expected %s, got %s", processInfo.PID, stored.PID)
+	}
+}
+
+func TestIngestRequest_ProcessInfo(t *testing.T) {
+	processInfo := &ProcessInfo{
+		PID:     "12345",
+		Name:    "GradleDaemon",
+		VMFlags: []string{"-XX:+UseG1GC"},
+	}
+
+	request := IngestRequest{
+		RunID:       "test-run",
+		Data:        "00:00:01 | 12345 | GradleDaemon | 100MB | 200MB | 300MB",
+		ProcessInfo: processInfo,
+	}
+
+	jsonData, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("Failed to marshal IngestRequest: %v", err)
+	}
+
+	var unmarshaled IngestRequest
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal IngestRequest: %v", err)
+	}
+
+	if unmarshaled.ProcessInfo == nil {
+		t.Fatal("ProcessInfo should not be nil")
+	}
+
+	if unmarshaled.ProcessInfo.PID != processInfo.PID {
+		t.Errorf("PID mismatch: expected %s, got %s", processInfo.PID, unmarshaled.ProcessInfo.PID)
+	}
+}
+
+func TestIngestRequest_WithoutProcessInfo(t *testing.T) {
+	request := IngestRequest{
+		RunID:       "test-run",
+		Data:        "00:00:01 | 12345 | GradleDaemon | 100MB | 200MB | 300MB",
+		ProcessInfo: nil,
+	}
+
+	jsonData, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("Failed to marshal IngestRequest without ProcessInfo: %v", err)
+	}
+
+	var unmarshaled IngestRequest
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal IngestRequest without ProcessInfo: %v", err)
+	}
+
+	if unmarshaled.ProcessInfo != nil {
+		t.Error("ProcessInfo should be nil when not provided")
+	}
+}

--- a/frontend/public/runs/[runId].html
+++ b/frontend/public/runs/[runId].html
@@ -98,6 +98,58 @@
             color: #111827;
         }
 
+        .process-info-section {
+            background: white;
+            border: 1px solid #e5e7eb;
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .process-info-section h2 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: #111827;
+            margin-bottom: 1.5rem;
+        }
+
+        .process-info-card {
+            background: #f9fafb;
+            border: 1px solid #e5e7eb;
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .process-info-card h3 {
+            font-size: 1.125rem;
+            font-weight: 600;
+            color: #111827;
+            margin-bottom: 0.5rem;
+        }
+
+        .process-info-card .process-meta {
+            font-size: 0.875rem;
+            color: #6b7280;
+            margin-bottom: 1rem;
+        }
+
+        .vm-flags-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 0.5rem;
+        }
+
+        .vm-flag {
+            background: #e5e7eb;
+            color: #374151;
+            padding: 0.25rem 0.75rem;
+            border-radius: 0.375rem;
+            font-family: 'Courier New', monospace;
+            font-size: 0.875rem;
+        }
+
         .status-in-progress {
             color: #2563eb;
         }
@@ -342,10 +394,36 @@
         function renderDashboard(runId, data) {
             const isFinished = data.finished;
             const samples = data.samples || [];
+            const processInfo = data.process_info || {};
             window.currentSamples = samples;
             
             const refreshStatus = isFinished ? 'Stopped' : `Active (${refreshInterval}s)`;
             const lastRefreshText = lastRefreshTime ? lastRefreshTime.toLocaleTimeString() : 'Never';
+            
+            // Render process info section
+            let processInfoHtml = '';
+            if (Object.keys(processInfo).length > 0) {
+                processInfoHtml = '<div class="process-info-section">';
+                processInfoHtml += '<h2>Process Information</h2>';
+                for (const [pid, info] of Object.entries(processInfo)) {
+                    const vmFlags = info.vm_flags || [];
+                    processInfoHtml += '<div class="process-info-card">';
+                    processInfoHtml += `<h3>${info.name || 'Unknown'}</h3>`;
+                    processInfoHtml += `<div class="process-meta">PID: ${pid}</div>`;
+                    if (vmFlags.length > 0) {
+                        processInfoHtml += '<div><strong>VM Flags:</strong></div>';
+                        processInfoHtml += '<div class="vm-flags-list">';
+                        vmFlags.forEach(flag => {
+                            processInfoHtml += `<span class="vm-flag">${escapeHtml(flag)}</span>`;
+                        });
+                        processInfoHtml += '</div>';
+                    } else {
+                        processInfoHtml += '<div class="process-meta">No VM flags available</div>';
+                    }
+                    processInfoHtml += '</div>';
+                }
+                processInfoHtml += '</div>';
+            }
             
             document.getElementById('content').innerHTML = `
                 <div class="run-info">
@@ -390,6 +468,8 @@
                         <p>${refreshStatus}</p>
                     </div>
                 </div>
+
+                ${processInfoHtml}
 
                 <div class="chart-container">
                     <div class="downloads-toolbar">
@@ -894,6 +974,13 @@
             } catch (e) {
                 console.error('Failed to download CSV:', e);
             }
+        }
+
+        function escapeHtml(str) {
+            if (str === undefined || str === null) return '';
+            const div = document.createElement('div');
+            div.textContent = str;
+            return div.innerHTML;
         }
 
         function escapeCsv(value) {


### PR DESCRIPTION
- Add ProcessInfo model to store VM flags per process (PID -> VM flags)
- Update RunDoc to include ProcessInfo map
- Add StoreProcessInfo method to store VM flags in Firestore
- Update Ingest handler to accept and store process info
- Update GetRun handler to include process info in API response
- Modify monitor script to detect new processes and retrieve VM flags using jinfo
- Add get_vm_flags() and send_process_info_to_backend() functions
- Update frontend to display VM flags per process in new Process Information section
- VM flags are retrieved once per process when first detected
- Add comprehensive tests for ProcessInfo model and handlers