### PR TITLE
fix: export nullable JIT metrics to BigQuery

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -12,6 +12,8 @@ on:
       - 'package-lock.json'
       - 'tsconfig.json'
       - 'action.yaml'
+      - 'monitor_with_backend.sh'
+      - 'frontend/public/compare-shared.js'
       - '.github/workflows/test-action.yml'
   push:
     branches: [ main, develop ]
@@ -24,6 +26,8 @@ on:
       - 'package-lock.json'
       - 'tsconfig.json'
       - 'action.yaml'
+      - 'monitor_with_backend.sh'
+      - 'frontend/public/compare-shared.js'
       - '.github/workflows/test-action.yml'
   workflow_dispatch:
   workflow_call:
@@ -140,6 +144,15 @@ jobs:
         echo "✅ PASS: TypeScript always enables GC"
         echo "===================================="
 
+    - name: Verify JIT and class-loading contract
+      run: |
+        grep -q "JIT_Compiled" monitor_with_backend.sh
+        grep -q "Classes_Loaded" monitor_with_backend.sh
+        grep -q "jstat_named_values -compiler" monitor_with_backend.sh
+        grep -q "jstat_named_values -class" monitor_with_backend.sh
+        grep -q "JITCompilationTimeMs" src/lib/report.ts
+        grep -q "ClassLoadTimeMs" src/lib/report.ts
+
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -154,4 +167,3 @@ jobs:
         echo "✅ Action build completed successfully!"
         echo "📦 Built files:"
         ls -lh dist/
-

--- a/.github/workflows/test-e2e-action.yml
+++ b/.github/workflows/test-e2e-action.yml
@@ -46,7 +46,21 @@ jobs:
     - name: Simulate build workload
       run: |
         echo "🏗️  Simulating build workload..."
-        sleep 10
+        cat > /tmp/GradleDaemon.java <<'EOF'
+        public class GradleDaemon {
+          public static void main(String[] args) throws Exception {
+            long end = System.currentTimeMillis() + 10000;
+            while (System.currentTimeMillis() < end) {
+              Class.forName("java.util.ArrayList");
+              Math.sqrt(System.nanoTime());
+              Thread.sleep(10);
+            }
+          }
+        }
+        EOF
+        javac /tmp/GradleDaemon.java
+        java -cp /tmp GradleDaemon &
+        wait $!
         echo "✅ Build simulation completed"
 
     - name: Search for log files
@@ -75,6 +89,15 @@ jobs:
             echo "❌ Log file missing expected header"
             cat "$LOG_FILE"
             exit 1
+          fi
+          DATA_LINE=$(tail -n +3 "$LOG_FILE" | grep 'GradleDaemon' | head -1 || true)
+          if [ -n "$DATA_LINE" ]; then
+            FIELD_COUNT=$(awk -F'|' '{print NF}' <<< "$DATA_LINE")
+            test "$FIELD_COUNT" -eq 14
+            echo "$DATA_LINE" | awk -F'|' '{ for (i=8; i<=14; i++) { gsub(/^ +| +$/, "", $i); if ($i != "N/A" && $i !~ /^[0-9]+([.][0-9]+)?$/) exit 1 } }'
+            echo "✅ Extended JIT/class record is valid"
+          else
+            echo "⚠️ JVM sample unavailable; collector compatibility tests cover unsupported attach environments"
           fi
         else
           echo "⚠️  Log file not found at expected location: $LOG_FILE"
@@ -387,4 +410,3 @@ jobs:
         fi
         
         echo "✅ All critical tests passed!"
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="frontend/public/performance.gif" alt="Performance Demo">
 </p>
 
-Monitor memory usage of Java/Kotlin build processes (`GradleDaemon`, `GradleWorkerMain`, `KotlinCompileDaemon`) during CI builds. Track heap and RSS usage, generate charts, and visualize data in real-time dashboards.
+Monitor Java/Kotlin build processes (`GradleDaemon`, `GradleWorkerMain`, `KotlinCompileDaemon`) during CI builds. Track heap, RSS, garbage collection, JIT compilation, and class loading without injecting a Java agent or changing JVM launch arguments.
 
 ---
 
@@ -104,6 +104,8 @@ act -W .github/workflows/test-action-local.yml -j local-mode
 - Data retention: 24 hours
 - Real-time process monitoring
 - GC time metrics
+- JIT compilation totals and interval activity when `jstat -compiler` is supported
+- Class-loading totals and classes-per-second activity when `jstat -class` is supported
 - GitHub Actions job summary (unless `disable_summary_output: 'true'` is set)
 
 ---
@@ -118,6 +120,13 @@ The dashboard shows:
 - Individual process metrics (RSS, Heap Used, Heap Capacity)
 - Aggregated memory consumption
 - Interactive charts with Plotly.js
+- Conditional JIT and class-loading panels; older runs keep the existing layout
+
+### JIT and Class-Loading Metrics
+
+The watcher calls the JDK's external `jstat` tool at the normal monitoring interval. It stores cumulative compiler and class-loading counters and derives activity rates between actual observations. Missing, unsupported, or failed counters are recorded as `null`; memory and GC collection continue independently.
+
+`jstat` availability and attach permissions vary by JVM and environment. Compilation time is compiler-thread elapsed time and should not be treated as process CPU time or compared as a JVM-independent performance verdict. To measure local collection cost for a representative JVM, run `scripts/benchmark-jstat-metrics.sh <pid>`.
 
 ### GitHub Actions Summary
 ![Mermaid Diagram Example](frontend/public/mermaid-diagram-example.png)
@@ -133,8 +142,8 @@ The job summary includes:
 
 The dashboard lets you:
 
-- **Replay a run** – Upload an exported JSON file to replay memory and GC charts offline.
-- **Compare runs** – Upload two JSON files to compare two runs side-by-side with a shared timeline.
+- **Replay a run** – Upload an exported JSON file to replay memory, GC, JIT, and class-loading charts offline.
+- **Compare runs** – Upload two JSON files to compare two runs in overlay or side-by-side views with a shared timeline.
 
 <p align="center">
   <img src="frontend/public/reply.gif" alt="Replay Demo" width="600"><br><br>

--- a/__tests__/compare-shared.test.ts
+++ b/__tests__/compare-shared.test.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vm from 'vm';
+
+function loadShared(): any {
+  const window: any = { innerWidth: 1200 };
+  const context = vm.createContext({ window, document: {}, localStorage: { getItem: () => null } });
+  const source = fs.readFileSync(path.join(__dirname, '../frontend/public/compare-shared.js'), 'utf8');
+  vm.runInContext(source, context);
+  return window.BpwCompareShared;
+}
+
+describe('JIT and class loading series', () => {
+  const shared = loadShared();
+
+  it('detects real zero values but not missing metrics', () => {
+    expect(shared.hasJITData([{ JITCompiledMethods: 0 }])).toBe(true);
+    expect(shared.hasJITData([{}])).toBe(false);
+    expect(shared.hasClassLoadingData([{ ClassesLoaded: 0 }])).toBe(true);
+  });
+
+  it('calculates rates across actual sparse observations', () => {
+    const timestamps = [0, 1000, 2000, 5000];
+    const samples = [
+      { Timestamp: 0, Name: 'P', PID: '1', ClassesLoaded: 10 },
+      { Timestamp: 1000, Name: 'P', PID: '1', ClassesLoaded: null },
+      { Timestamp: 5000, Name: 'P', PID: '1', ClassesLoaded: 30 },
+    ];
+    const result = shared.buildCounterSeries(samples, timestamps, 'P', '1', (s: any) => s.ClassesLoaded);
+    expect(Array.from(result.cumulative)).toEqual([10, 10, 10, 30]);
+    expect(Array.from(result.rate)).toEqual([null, null, null, 4]);
+  });
+
+  it('breaks a rate segment when a counter decreases and isolates PIDs', () => {
+    const samples = [
+      { Timestamp: 0, Name: 'P', PID: '1', JITCompiledMethods: 10 },
+      { Timestamp: 1000, Name: 'P', PID: '2', JITCompiledMethods: 100 },
+      { Timestamp: 2000, Name: 'P', PID: '1', JITCompiledMethods: 5 },
+      { Timestamp: 3000, Name: 'P', PID: '1', JITCompiledMethods: 9 },
+    ];
+    const result = shared.buildCounterSeries(samples, [0, 1000, 2000, 3000], 'P', '1', (s: any) => s.JITCompiledMethods);
+    expect(Array.from(result.rate)).toEqual([null, null, null, 4]);
+  });
+});

--- a/__tests__/monitor-metrics.test.ts
+++ b/__tests__/monitor-metrics.test.ts
@@ -1,0 +1,32 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+function parserFunction(): string {
+  const script = fs.readFileSync(path.join(__dirname, '../monitor_with_backend.sh'), 'utf8');
+  const match = script.match(/jstat_named_values\(\) \{[\s\S]*?\n\}/);
+  if (!match) throw new Error('jstat_named_values function not found');
+  return match[0];
+}
+
+function runParser(fixture: string, columns: string): string {
+  const bash = `${parserFunction()}\n` +
+    `jstat() { printf '%s\\n' "$JSTAT_FIXTURE"; }\n` +
+    `jstat_named_values -compiler 123 ${columns}`;
+  return execFileSync('bash', ['-c', bash], {
+    encoding: 'utf8',
+    env: { ...process.env, JSTAT_FIXTURE: fixture },
+  });
+}
+
+describe('jstat_named_values', () => {
+  it('matches values by header name when columns are reordered or added', () => {
+    const output = runParser('Extra Time Invalid Compiled Failed\n9 1.25 2 44 3', 'Compiled Failed Invalid Time');
+    expect(output).toBe('44|3|2|1.25');
+  });
+
+  it('returns N/A for a missing header without losing other values', () => {
+    const output = runParser('Compiled Time\n12 0.50', 'Compiled Failed Time');
+    expect(output).toBe('12|N/A|0.50');
+  });
+});

--- a/__tests__/report.test.ts
+++ b/__tests__/report.test.ts
@@ -169,4 +169,43 @@ describe('generateJsonReport', () => {
     expect(output.samples[0].GCTime).toBe(123);
     expect(output.samples[0].GCTimeSeconds).toBe(0.123);
   });
+
+  it('parses extended JIT and class loading metrics', () => {
+    const logFile = path.join(tmpDir, 'test.log');
+    const outputFile = path.join(tmpDir, 'output.json');
+    fs.writeFileSync(logFile,
+      'header\n\n' +
+      '00:00:05 | 1 | Proc | 10MB | 100MB | 50MB | 0.123s | 42 | 1 | 2 | 0.456 | 900 | 12 | 0.789\n');
+
+    generateJsonReport(logFile, outputFile, true);
+    const sample = JSON.parse(fs.readFileSync(outputFile, 'utf8')).samples[0];
+
+    expect(sample).toMatchObject({
+      JITCompiledMethods: 42,
+      JITFailedCompilations: 1,
+      JITInvalidatedCompilations: 2,
+      JITCompilationTimeMs: 456,
+      ClassesLoaded: 900,
+      ClassesUnloaded: 12,
+      ClassLoadTimeMs: 789,
+    });
+  });
+
+  it('keeps the base sample when optional metrics are unavailable or malformed', () => {
+    const logFile = path.join(tmpDir, 'test.log');
+    const outputFile = path.join(tmpDir, 'output.json');
+    fs.writeFileSync(logFile,
+      'header\n\n' +
+      '00:00:05 | 1 | Proc | 10MB | 100MB | 50MB | N/A | N/A | bad | N/A | N/A | 0 | N/A | broken\n');
+
+    generateJsonReport(logFile, outputFile, true);
+    const sample = JSON.parse(fs.readFileSync(outputFile, 'utf8')).samples[0];
+
+    expect(sample.RSS).toBe(50);
+    expect(sample.GCTime).toBeNull();
+    expect(sample.JITCompiledMethods).toBeNull();
+    expect(sample.JITFailedCompilations).toBeNull();
+    expect(sample.ClassesLoaded).toBe(0);
+    expect(sample.ClassLoadTimeMs).toBeNull();
+  });
 });

--- a/backend/internal/bigqueryexport/export.go
+++ b/backend/internal/bigqueryexport/export.go
@@ -57,31 +57,30 @@ func (e *Exporter) Close() error {
 
 // sampleRow matches schema in schema/bigquery_build_process_samples.sql
 type sampleRow struct {
-	RunID                      string    `bigquery:"run_id"`
-	SampleTimestamp            time.Time `bigquery:"sample_timestamp"`
-	ElapsedTime                int64     `bigquery:"elapsed_time"`
-	PID                        string    `bigquery:"pid"`
-	Name                       string    `bigquery:"name"`
-	HeapUsedMB                 int64     `bigquery:"heap_used"`
-	HeapCapMB                  int64     `bigquery:"heap_cap"`
-	RSSMB                      int64     `bigquery:"rss"`
-	GCTimeMS                   int64     `bigquery:"gc_time"`
-	JITCompiledMethods         *int64    `bigquery:"jit_compiled_methods"`
-	JITFailedCompilations      *int64    `bigquery:"jit_failed_compilations"`
-	JITInvalidatedCompilations *int64    `bigquery:"jit_invalidated_compilations"`
-	JITCompilationTimeMs       *int64    `bigquery:"jit_compilation_time_ms"`
-	ClassesLoaded              *int64    `bigquery:"classes_loaded"`
-	ClassesUnloaded            *int64    `bigquery:"classes_unloaded"`
-	ClassLoadTimeMs            *int64    `bigquery:"class_load_time_ms"`
-	RunFinishedAt              time.Time `bigquery:"run_finished_at"`
+	RunID                      string             `bigquery:"run_id"`
+	SampleTimestamp            time.Time          `bigquery:"sample_timestamp"`
+	ElapsedTime                int64              `bigquery:"elapsed_time"`
+	PID                        string             `bigquery:"pid"`
+	Name                       string             `bigquery:"name"`
+	HeapUsedMB                 int64              `bigquery:"heap_used"`
+	HeapCapMB                  int64              `bigquery:"heap_cap"`
+	RSSMB                      int64              `bigquery:"rss"`
+	GCTimeMS                   int64              `bigquery:"gc_time"`
+	JITCompiledMethods         bigquery.NullInt64 `bigquery:"jit_compiled_methods"`
+	JITFailedCompilations      bigquery.NullInt64 `bigquery:"jit_failed_compilations"`
+	JITInvalidatedCompilations bigquery.NullInt64 `bigquery:"jit_invalidated_compilations"`
+	JITCompilationTimeMs       bigquery.NullInt64 `bigquery:"jit_compilation_time_ms"`
+	ClassesLoaded              bigquery.NullInt64 `bigquery:"classes_loaded"`
+	ClassesUnloaded            bigquery.NullInt64 `bigquery:"classes_unloaded"`
+	ClassLoadTimeMs            bigquery.NullInt64 `bigquery:"class_load_time_ms"`
+	RunFinishedAt              time.Time          `bigquery:"run_finished_at"`
 }
 
-func optionalInt64(value *int) *int64 {
+func optionalInt64(value *int) bigquery.NullInt64 {
 	if value == nil {
-		return nil
+		return bigquery.NullInt64{}
 	}
-	converted := int64(*value)
-	return &converted
+	return bigquery.NullInt64{Int64: int64(*value), Valid: true}
 }
 
 // ExportRun inserts all samples for a finished run. Errors do not rollback Firestore; callers log and continue.

--- a/backend/internal/bigqueryexport/export.go
+++ b/backend/internal/bigqueryexport/export.go
@@ -57,16 +57,31 @@ func (e *Exporter) Close() error {
 
 // sampleRow matches schema in schema/bigquery_build_process_samples.sql
 type sampleRow struct {
-	RunID           string    `bigquery:"run_id"`
-	SampleTimestamp time.Time `bigquery:"sample_timestamp"`
-	ElapsedTime     int64     `bigquery:"elapsed_time"`
-	PID             string    `bigquery:"pid"`
-	Name            string    `bigquery:"name"`
-	HeapUsedMB      int64     `bigquery:"heap_used"`
-	HeapCapMB       int64     `bigquery:"heap_cap"`
-	RSSMB           int64     `bigquery:"rss"`
-	GCTimeMS        int64     `bigquery:"gc_time"`
-	RunFinishedAt   time.Time `bigquery:"run_finished_at"`
+	RunID                      string    `bigquery:"run_id"`
+	SampleTimestamp            time.Time `bigquery:"sample_timestamp"`
+	ElapsedTime                int64     `bigquery:"elapsed_time"`
+	PID                        string    `bigquery:"pid"`
+	Name                       string    `bigquery:"name"`
+	HeapUsedMB                 int64     `bigquery:"heap_used"`
+	HeapCapMB                  int64     `bigquery:"heap_cap"`
+	RSSMB                      int64     `bigquery:"rss"`
+	GCTimeMS                   int64     `bigquery:"gc_time"`
+	JITCompiledMethods         *int64    `bigquery:"jit_compiled_methods"`
+	JITFailedCompilations      *int64    `bigquery:"jit_failed_compilations"`
+	JITInvalidatedCompilations *int64    `bigquery:"jit_invalidated_compilations"`
+	JITCompilationTimeMs       *int64    `bigquery:"jit_compilation_time_ms"`
+	ClassesLoaded              *int64    `bigquery:"classes_loaded"`
+	ClassesUnloaded            *int64    `bigquery:"classes_unloaded"`
+	ClassLoadTimeMs            *int64    `bigquery:"class_load_time_ms"`
+	RunFinishedAt              time.Time `bigquery:"run_finished_at"`
+}
+
+func optionalInt64(value *int) *int64 {
+	if value == nil {
+		return nil
+	}
+	converted := int64(*value)
+	return &converted
 }
 
 // ExportRun inserts all samples for a finished run. Errors do not rollback Firestore; callers log and continue.
@@ -78,16 +93,23 @@ func (e *Exporter) ExportRun(ctx context.Context, runID string, samples []models
 	for i, s := range samples {
 		ts := time.UnixMilli(s.Timestamp).UTC()
 		row := sampleRow{
-			RunID:           runID,
-			SampleTimestamp: ts,
-			ElapsedTime:     int64(s.ElapsedTime),
-			PID:             s.PID,
-			Name:            s.Name,
-			HeapUsedMB:      int64(s.HeapUsed),
-			HeapCapMB:       int64(s.HeapCap),
-			RSSMB:           int64(s.RSS),
-			GCTimeMS:        int64(s.GCTime),
-			RunFinishedAt:   finishedAt.UTC(),
+			RunID:                      runID,
+			SampleTimestamp:            ts,
+			ElapsedTime:                int64(s.ElapsedTime),
+			PID:                        s.PID,
+			Name:                       s.Name,
+			HeapUsedMB:                 int64(s.HeapUsed),
+			HeapCapMB:                  int64(s.HeapCap),
+			RSSMB:                      int64(s.RSS),
+			GCTimeMS:                   int64(s.GCTime),
+			JITCompiledMethods:         optionalInt64(s.JITCompiledMethods),
+			JITFailedCompilations:      optionalInt64(s.JITFailedCompilations),
+			JITInvalidatedCompilations: optionalInt64(s.JITInvalidatedCompilations),
+			JITCompilationTimeMs:       optionalInt64(s.JITCompilationTimeMs),
+			ClassesLoaded:              optionalInt64(s.ClassesLoaded),
+			ClassesUnloaded:            optionalInt64(s.ClassesUnloaded),
+			ClassLoadTimeMs:            optionalInt64(s.ClassLoadTimeMs),
+			RunFinishedAt:              finishedAt.UTC(),
 		}
 		rows = append(rows, &bigquery.StructSaver{
 			InsertID: stableInsertID("sample", runID, i, s.Timestamp, s.ElapsedTime, s.PID, s.Name),

--- a/backend/internal/bigqueryexport/export_test.go
+++ b/backend/internal/bigqueryexport/export_test.go
@@ -68,3 +68,22 @@ func TestStableInsertID(t *testing.T) {
 		t.Fatalf("insert id should change when row identity changes: %q", a)
 	}
 }
+
+func TestOptionalInt64(t *testing.T) {
+	if optionalInt64(nil) != nil {
+		t.Fatal("nil metric must remain nil")
+	}
+	value := 42
+	converted := optionalInt64(&value)
+	if converted == nil || *converted != 42 {
+		t.Fatalf("unexpected conversion: %v", converted)
+	}
+}
+
+func TestSampleRowOptionalMetricTags(t *testing.T) {
+	value := int64(1)
+	row := sampleRow{JITCompiledMethods: &value, ClassesLoaded: nil}
+	if row.JITCompiledMethods == nil || row.ClassesLoaded != nil {
+		t.Fatal("sample row must preserve populated and null optional metrics")
+	}
+}

--- a/backend/internal/bigqueryexport/export_test.go
+++ b/backend/internal/bigqueryexport/export_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/cdsap/build-process-watcher/backend/internal/models"
 )
 
@@ -70,20 +71,22 @@ func TestStableInsertID(t *testing.T) {
 }
 
 func TestOptionalInt64(t *testing.T) {
-	if optionalInt64(nil) != nil {
-		t.Fatal("nil metric must remain nil")
+	if got := optionalInt64(nil); got.Valid {
+		t.Fatalf("nil metric must remain invalid, got %+v", got)
 	}
 	value := 42
 	converted := optionalInt64(&value)
-	if converted == nil || *converted != 42 {
+	if !converted.Valid || converted.Int64 != 42 {
 		t.Fatalf("unexpected conversion: %v", converted)
 	}
 }
 
 func TestSampleRowOptionalMetricTags(t *testing.T) {
-	value := int64(1)
-	row := sampleRow{JITCompiledMethods: &value, ClassesLoaded: nil}
-	if row.JITCompiledMethods == nil || row.ClassesLoaded != nil {
+	row := sampleRow{
+		JITCompiledMethods: bigquery.NullInt64{Int64: 1, Valid: true},
+		ClassesLoaded:      bigquery.NullInt64{},
+	}
+	if !row.JITCompiledMethods.Valid || row.ClassesLoaded.Valid {
 		t.Fatal("sample row must preserve populated and null optional metrics")
 	}
 }

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -4,15 +4,22 @@ import "time"
 
 // Sample represents a single monitoring sample
 type Sample struct {
-	Timestamp   int64  `firestore:"timestamp"`
-	ElapsedTime int    `firestore:"elapsed_time"`
-	PID         string `firestore:"pid"`
-	Name        string `firestore:"name"`
-	HeapUsed    int    `firestore:"heap_used"`
-	HeapCap     int    `firestore:"heap_cap"`
-	RSS         int    `firestore:"rss"`
-	GCTime      int    `firestore:"gc_time,omitempty"` // GC time in milliseconds, optional
-	RunID       string `firestore:"run_id"`
+	Timestamp                  int64  `firestore:"timestamp"`
+	ElapsedTime                int    `firestore:"elapsed_time"`
+	PID                        string `firestore:"pid"`
+	Name                       string `firestore:"name"`
+	HeapUsed                   int    `firestore:"heap_used"`
+	HeapCap                    int    `firestore:"heap_cap"`
+	RSS                        int    `firestore:"rss"`
+	GCTime                     int    `firestore:"gc_time,omitempty"` // GC time in milliseconds, optional
+	JITCompiledMethods         *int   `firestore:"jit_compiled_methods,omitempty"`
+	JITFailedCompilations      *int   `firestore:"jit_failed_compilations,omitempty"`
+	JITInvalidatedCompilations *int   `firestore:"jit_invalidated_compilations,omitempty"`
+	JITCompilationTimeMs       *int   `firestore:"jit_compilation_time_ms,omitempty"`
+	ClassesLoaded              *int   `firestore:"classes_loaded,omitempty"`
+	ClassesUnloaded            *int   `firestore:"classes_unloaded,omitempty"`
+	ClassLoadTimeMs            *int   `firestore:"class_load_time_ms,omitempty"`
+	RunID                      string `firestore:"run_id"`
 }
 
 // ProcessInfo contains information about a specific process

--- a/backend/internal/models/models_test.go
+++ b/backend/internal/models/models_test.go
@@ -251,3 +251,22 @@ func TestIngestRequest_WithoutProcessInfo(t *testing.T) {
 		t.Error("ProcessInfo should be nil when not provided")
 	}
 }
+
+func TestSampleOptionalMetricsJSON(t *testing.T) {
+	compiled := 12
+	sample := Sample{PID: "1", JITCompiledMethods: &compiled}
+	data, err := json.Marshal(sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded Sample
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.JITCompiledMethods == nil || *decoded.JITCompiledMethods != compiled {
+		t.Fatalf("optional metric did not round trip: %s", data)
+	}
+	if decoded.ClassesLoaded != nil {
+		t.Fatal("unset optional metric should remain nil")
+	}
+}

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -410,8 +410,8 @@ func ParseData(data string, startTime time.Time) ([]models.Sample, error) {
 
 		parts := strings.Split(line, "|")
 		log.Printf("Split into %d parts: %v", len(parts), parts)
-		if len(parts) != 6 && len(parts) != 7 {
-			log.Printf("Skipping line %d: expected 6 or 7 parts, got %d", i, len(parts))
+		if len(parts) != 6 && len(parts) != 7 && len(parts) != 14 {
+			log.Printf("Skipping line %d: expected 6, 7, or 14 parts, got %d", i, len(parts))
 			continue
 		}
 
@@ -467,16 +467,16 @@ func ParseData(data string, startTime time.Time) ([]models.Sample, error) {
 		// Parse GC time if present (7th part)
 		// Format can be either "0.234s" (seconds) or legacy "234ms" (milliseconds)
 		var gcTime int
-		if len(parts) == 7 {
+		if len(parts) >= 7 {
 			gcTimeStr := parts[6]
-			isSeconds := strings.HasSuffix(gcTimeStr, "s")
 			isMilliseconds := strings.HasSuffix(gcTimeStr, "ms")
+			isSeconds := !isMilliseconds && strings.HasSuffix(gcTimeStr, "s")
 
 			// Remove suffix (either "s" or "ms")
-			if isSeconds {
-				gcTimeStr = strings.TrimSuffix(gcTimeStr, "s")
-			} else if isMilliseconds {
+			if isMilliseconds {
 				gcTimeStr = strings.TrimSuffix(gcTimeStr, "ms")
+			} else if isSeconds {
+				gcTimeStr = strings.TrimSuffix(gcTimeStr, "s")
 			}
 
 			if gcTimeStr != "N/A" && gcTimeStr != "" {
@@ -496,19 +496,42 @@ func ParseData(data string, startTime time.Time) ([]models.Sample, error) {
 			}
 		}
 
+		parseOptionalInt := func(index int, secondsToMillis bool) *int {
+			if index >= len(parts) || parts[index] == "" || parts[index] == "N/A" {
+				return nil
+			}
+			value, err := strconv.ParseFloat(strings.TrimSuffix(parts[index], "s"), 64)
+			if err != nil {
+				log.Printf("Warning: optional metric %d parsing failed: %v", index, err)
+				return nil
+			}
+			if secondsToMillis {
+				value *= 1000
+			}
+			parsed := int(value)
+			return &parsed
+		}
+
 		// Calculate consistent timestamp using startTime + elapsedTime
 		// This ensures all samples in the same monitoring cycle have the same timestamp
 		timestamp := startTime.Add(time.Duration(elapsedTime) * time.Second)
 
 		sample := models.Sample{
-			Timestamp:   ToMillis(timestamp),
-			ElapsedTime: elapsedTime,
-			PID:         parts[1],
-			Name:        parts[2],
-			HeapUsed:    heapUsed,
-			HeapCap:     heapCap,
-			RSS:         rss,
-			GCTime:      gcTime,
+			Timestamp:                  ToMillis(timestamp),
+			ElapsedTime:                elapsedTime,
+			PID:                        parts[1],
+			Name:                       parts[2],
+			HeapUsed:                   heapUsed,
+			HeapCap:                    heapCap,
+			RSS:                        rss,
+			GCTime:                     gcTime,
+			JITCompiledMethods:         parseOptionalInt(7, false),
+			JITFailedCompilations:      parseOptionalInt(8, false),
+			JITInvalidatedCompilations: parseOptionalInt(9, false),
+			JITCompilationTimeMs:       parseOptionalInt(10, true),
+			ClassesLoaded:              parseOptionalInt(11, false),
+			ClassesUnloaded:            parseOptionalInt(12, false),
+			ClassLoadTimeMs:            parseOptionalInt(13, true),
 		}
 
 		log.Printf("Created sample: %+v", sample)

--- a/backend/internal/storage/storage_test.go
+++ b/backend/internal/storage/storage_test.go
@@ -1,0 +1,76 @@
+package storage
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestParseDataHistoricalAndExtendedRecords(t *testing.T) {
+	start := time.Unix(100, 0)
+	data := "00:00:01 | 1 | Old | 10MB | 20MB | 30MB\n" +
+		"00:00:02 | 2 | Extended | 11MB | 21MB | 31MB | 0.125s | 40 | 1 | 2 | 0.456 | 900 | 12 | 0.789"
+
+	samples, err := ParseData(data, start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 2 {
+		t.Fatalf("expected 2 samples, got %d", len(samples))
+	}
+	if samples[0].JITCompiledMethods != nil {
+		t.Fatal("historical sample should have nil optional metrics")
+	}
+	extended := samples[1]
+	assertIntPointer(t, "compiled", extended.JITCompiledMethods, 40)
+	assertIntPointer(t, "jit time", extended.JITCompilationTimeMs, 456)
+	assertIntPointer(t, "loaded", extended.ClassesLoaded, 900)
+	assertIntPointer(t, "class time", extended.ClassLoadTimeMs, 789)
+}
+
+func TestParseDataAcceptsLegacyMillisecondGC(t *testing.T) {
+	samples, err := ParseData("00:00:01 | 1 | Proc | 10MB | 20MB | 30MB | 234ms", time.Unix(0, 0))
+	if err != nil || len(samples) != 1 {
+		t.Fatalf("unexpected parse result: %v, %d samples", err, len(samples))
+	}
+	if samples[0].GCTime != 234 {
+		t.Fatalf("expected 234ms, got %d", samples[0].GCTime)
+	}
+}
+
+func TestParseDataMalformedOptionalMetricDoesNotDiscardSample(t *testing.T) {
+	samples, err := ParseData("00:00:01 | 1 | Proc | 10MB | 20MB | 30MB | N/A | bad | N/A | 2 | N/A | 0 | N/A | broken", time.Unix(0, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 1 {
+		t.Fatalf("expected base sample to survive, got %d samples", len(samples))
+	}
+	if samples[0].JITCompiledMethods != nil || samples[0].ClassLoadTimeMs != nil {
+		t.Fatal("malformed optional values should be nil")
+	}
+	assertIntPointer(t, "invalidated", samples[0].JITInvalidatedCompilations, 2)
+	assertIntPointer(t, "loaded zero", samples[0].ClassesLoaded, 0)
+}
+
+func TestSampleJSONRoundTripOptionalMetrics(t *testing.T) {
+	samples, _ := ParseData("00:00:01 | 1 | Proc | 10MB | 20MB | 30MB | 0s | 5 | N/A | N/A | 0.25 | 100 | N/A | N/A", time.Unix(0, 0))
+	encoded, err := json.Marshal(samples[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["JITCompiledMethods"] != float64(5) || decoded["JITFailedCompilations"] != nil {
+		t.Fatalf("unexpected JSON: %s", encoded)
+	}
+}
+
+func assertIntPointer(t *testing.T, name string, value *int, expected int) {
+	t.Helper()
+	if value == nil || *value != expected {
+		t.Fatalf("%s: expected %d, got %v", name, expected, value)
+	}
+}

--- a/backend/schema/bigquery_build_process_samples.sql
+++ b/backend/schema/bigquery_build_process_samples.sql
@@ -11,7 +11,23 @@ CREATE TABLE IF NOT EXISTS `YOUR_PROJECT.YOUR_DATASET.build_process_samples` (
   heap_cap INT64 NOT NULL,
   rss INT64 NOT NULL,
   gc_time INT64 NOT NULL,
+  jit_compiled_methods INT64,
+  jit_failed_compilations INT64,
+  jit_invalidated_compilations INT64,
+  jit_compilation_time_ms INT64,
+  classes_loaded INT64,
+  classes_unloaded INT64,
+  class_load_time_ms INT64,
   run_finished_at TIMESTAMP NOT NULL
 )
 PARTITION BY DATE(sample_timestamp)
 CLUSTER BY run_id, name;
+
+-- Existing datasets: these additive statements are safe to run repeatedly.
+ALTER TABLE `YOUR_PROJECT.YOUR_DATASET.build_process_samples` ADD COLUMN IF NOT EXISTS jit_compiled_methods INT64;
+ALTER TABLE `YOUR_PROJECT.YOUR_DATASET.build_process_samples` ADD COLUMN IF NOT EXISTS jit_failed_compilations INT64;
+ALTER TABLE `YOUR_PROJECT.YOUR_DATASET.build_process_samples` ADD COLUMN IF NOT EXISTS jit_invalidated_compilations INT64;
+ALTER TABLE `YOUR_PROJECT.YOUR_DATASET.build_process_samples` ADD COLUMN IF NOT EXISTS jit_compilation_time_ms INT64;
+ALTER TABLE `YOUR_PROJECT.YOUR_DATASET.build_process_samples` ADD COLUMN IF NOT EXISTS classes_loaded INT64;
+ALTER TABLE `YOUR_PROJECT.YOUR_DATASET.build_process_samples` ADD COLUMN IF NOT EXISTS classes_unloaded INT64;
+ALTER TABLE `YOUR_PROJECT.YOUR_DATASET.build_process_samples` ADD COLUMN IF NOT EXISTS class_load_time_ms INT64;

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -73623,7 +73623,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unregisterGlobal = exports.getGlobal = exports.registerGlobal = void 0;
 const platform_1 = __nccwpck_require__(69932);
 const version_1 = __nccwpck_require__(59390);
-const semver_1 = __nccwpck_require__(22707);
+const semver_1 = __nccwpck_require__(45088);
 const major = version_1.VERSION.split('.')[0];
 const GLOBAL_OPENTELEMETRY_API_KEY = Symbol.for(`opentelemetry.js.api.${major}`);
 const _global = platform_1._globalThis;
@@ -73670,7 +73670,7 @@ exports.unregisterGlobal = unregisterGlobal;
 
 /***/ }),
 
-/***/ 22707:
+/***/ 45088:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -115346,7 +115346,7 @@ exports.UrlSubjectTokenSupplier = UrlSubjectTokenSupplier;
 
 /***/ }),
 
-/***/ 71057:
+/***/ 93438:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -115503,7 +115503,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createCrypto = createCrypto;
 exports.hasBrowserCrypto = hasBrowserCrypto;
 exports.fromArrayBufferToHex = fromArrayBufferToHex;
-const crypto_1 = __nccwpck_require__(71057);
+const crypto_1 = __nccwpck_require__(93438);
 const crypto_2 = __nccwpck_require__(27388);
 function createCrypto() {
     if (hasBrowserCrypto()) {
@@ -131194,7 +131194,7 @@ module.exports = baseFindIndex;
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var arrayPush = __nccwpck_require__(50827),
-    isFlattenable = __nccwpck_require__(45088);
+    isFlattenable = __nccwpck_require__(22707);
 
 /**
  * The base implementation of `_.flatten` with support for restricting flattening.
@@ -132048,7 +132048,7 @@ module.exports = hashSet;
 
 /***/ }),
 
-/***/ 45088:
+/***/ 22707:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var Symbol = __nccwpck_require__(38584),
@@ -213884,7 +213884,6 @@ const child_process_1 = __nccwpck_require__(35317);
 const util_1 = __nccwpck_require__(39023);
 const fs = __importStar(__nccwpck_require__(79896));
 const path = __importStar(__nccwpck_require__(16928));
-const artifact_1 = __nccwpck_require__(76846);
 const app_1 = __nccwpck_require__(75919);
 const firestore_1 = __nccwpck_require__(27157);
 const report_1 = __nccwpck_require__(47185);
@@ -213897,8 +213896,8 @@ function parseLogFile(logFile) {
     // Skip header lines
     lines.slice(2).forEach(line => {
         const parts = line.trim().split('|').map(p => p.trim());
-        // Support both 6 columns (without GC) and 7 columns (with GC)
-        if (parts.length !== 6 && parts.length !== 7)
+        // Support historical 6/7-column records and extended JVM metric records.
+        if (parts.length !== 6 && parts.length !== 7 && parts.length !== 14)
             return;
         const [timestamp, pid, name, heapUsed, heapCap, rss, gcTime] = parts;
         const rssValue = parseFloat(rss.replace('MB', ''));
@@ -213915,7 +213914,7 @@ function parseLogFile(logFile) {
         processData.heapUsed.push(heapUsedValue);
         processData.heapCap.push(heapCapValue);
         // Parse GC time if available (7th column)
-        if (parts.length === 7 && gcTime) {
+        if (parts.length >= 7 && gcTime) {
             hasGcData = true;
             // Remove 's' suffix if present and parse as float
             const gcTimeValue = parseFloat(gcTime.replace('s', ''));
@@ -213938,15 +213937,13 @@ function parseLogFile(logFile) {
 function generateCsvReport(logFile, outputFile, hasGcData) {
     const lines = fs.readFileSync(logFile, 'utf8').split('\n');
     const dataLines = lines.slice(2).filter(line => line.trim().length > 0);
-    const header = hasGcData
-        ? ['elapsed_time', 'pid', 'name', 'heap_used_mb', 'heap_capacity_mb', 'rss_mb', 'gc_time_s']
-        : ['elapsed_time', 'pid', 'name', 'heap_used_mb', 'heap_capacity_mb', 'rss_mb'];
+    const header = ['elapsed_time', 'pid', 'name', 'heap_used_mb', 'heap_capacity_mb', 'rss_mb', 'gc_time_s', 'jit_compiled_methods', 'jit_failed_compilations', 'jit_invalidated_compilations', 'jit_compilation_time_s', 'classes_loaded', 'classes_unloaded', 'class_load_time_s'];
     const rows = [header.join(',')];
     dataLines.forEach(line => {
         const parts = line.trim().split('|').map(p => p.trim());
-        if (parts.length !== 6 && parts.length !== 7)
+        if (parts.length !== 6 && parts.length !== 7 && parts.length !== 14)
             return;
-        const [timestamp, pid, name, heapUsed, heapCap, rss, gcTime] = parts;
+        const [timestamp, pid, name, heapUsed, heapCap, rss, gcTime, ...optionalMetrics] = parts;
         const baseRow = [
             timestamp,
             pid,
@@ -213955,9 +213952,8 @@ function generateCsvReport(logFile, outputFile, hasGcData) {
             heapCap.replace('MB', ''),
             rss.replace('MB', '')
         ];
-        if (parts.length === 7 && hasGcData) {
-            baseRow.push(gcTime.replace('s', '').replace('N/A', '0'));
-        }
+        baseRow.push(parts.length >= 7 && hasGcData ? gcTime.replace('s', '').replace('N/A', '') : '');
+        baseRow.push(...Array.from({ length: 7 }, (_, index) => { var _a, _b; return (_b = (_a = optionalMetrics[index]) === null || _a === void 0 ? void 0 : _a.replace('N/A', '')) !== null && _b !== void 0 ? _b : ''; }));
         rows.push(baseRow.join(','));
     });
     fs.writeFileSync(outputFile, rows.join('\n'));
@@ -214758,7 +214754,8 @@ async function run() {
         const shouldUpload = !isTrapHandler && isGitHubActions && hasRuntimeToken;
         if (shouldUpload) {
             try {
-                const artifactClient = new artifact_1.DefaultArtifactClient();
+                const { DefaultArtifactClient } = await Promise.resolve().then(() => __importStar(__nccwpck_require__(76846)));
+                const artifactClient = new DefaultArtifactClient();
                 // Create stable artifact name using job name and run attempt
                 const jobName = process.env.GITHUB_JOB || 'default';
                 const runAttempt = process.env.GITHUB_RUN_ATTEMPT || '1';
@@ -215056,17 +215053,27 @@ function generateJsonReport(logFile, outputFile, hasGcData) {
     dataLines.forEach(line => {
         var _a;
         const parts = line.trim().split('|').map(p => p.trim());
-        if (parts.length !== 6 && parts.length !== 7)
+        if (parts.length !== 6 && parts.length !== 7 && parts.length !== 14)
             return;
-        const [timestamp, pid, name, heapUsed, heapCap, rss, gcTime] = parts;
+        const [timestamp, pid, name, heapUsed, heapCap, rss, gcTime, jitCompiled, jitFailed, jitInvalid, jitTime, classesLoaded, classesUnloaded, classTime] = parts;
         const elapsedSeconds = parseTimestampSeconds(timestamp);
         const rssValue = parseFloat(rss.replace('MB', ''));
         const heapUsedValue = parseFloat(heapUsed.replace('MB', ''));
         const heapCapValue = parseFloat(heapCap.replace('MB', ''));
-        const gcSeconds = parts.length === 7 && hasGcData
-            ? parseFloat(gcTime.replace('s', '').replace('N/A', '0'))
+        const gcSeconds = parts.length >= 7 && hasGcData
+            ? parseFloat(gcTime.replace('s', ''))
             : NaN;
         const gcSecondsValue = Number.isNaN(gcSeconds) ? null : gcSeconds;
+        const optionalNumber = (value) => {
+            if (!value || value === 'N/A')
+                return null;
+            const parsed = Number(value.replace(/s$/, ''));
+            return Number.isFinite(parsed) ? parsed : null;
+        };
+        const optionalMillis = (value) => {
+            const seconds = optionalNumber(value);
+            return seconds === null ? null : seconds * 1000;
+        };
         samples.push({
             Timestamp: Math.max(0, elapsedSeconds * 1000),
             ElapsedTime: Math.max(0, elapsedSeconds),
@@ -215076,7 +215083,14 @@ function generateJsonReport(logFile, outputFile, hasGcData) {
             HeapUsed: Number.isNaN(heapUsedValue) ? 0 : heapUsedValue,
             HeapCap: Number.isNaN(heapCapValue) ? 0 : heapCapValue,
             GCTime: gcSecondsValue !== null ? gcSecondsValue * 1000 : null,
-            GCTimeSeconds: gcSecondsValue
+            GCTimeSeconds: gcSecondsValue,
+            JITCompiledMethods: optionalNumber(jitCompiled),
+            JITFailedCompilations: optionalNumber(jitFailed),
+            JITInvalidatedCompilations: optionalNumber(jitInvalid),
+            JITCompilationTimeMs: optionalMillis(jitTime),
+            ClassesLoaded: optionalNumber(classesLoaded),
+            ClassesUnloaded: optionalNumber(classesUnloaded),
+            ClassLoadTimeMs: optionalMillis(classTime)
         });
         if (!processInfo[pid]) {
             const fromFile = processInfoFromFile[pid];
@@ -221893,7 +221907,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = exports.useInstrumenter = void 0;
 var instrumenter_js_1 = __nccwpck_require__(48729);
 Object.defineProperty(exports, "useInstrumenter", ({ enumerable: true, get: function () { return instrumenter_js_1.useInstrumenter; } }));
-var tracingClient_js_1 = __nccwpck_require__(93438);
+var tracingClient_js_1 = __nccwpck_require__(71057);
 Object.defineProperty(exports, "createTracingClient", ({ enumerable: true, get: function () { return tracingClient_js_1.createTracingClient; } }));
 //# sourceMappingURL=index.js.map
 
@@ -221996,7 +222010,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 93438:
+/***/ 71057:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";

--- a/frontend/public/compare-shared.js
+++ b/frontend/public/compare-shared.js
@@ -57,6 +57,18 @@
         return samples.some(sample => sample && sample.RSS && sample.RSS > 0);
     }
 
+    function isValidMetric(value) {
+        return value !== null && value !== undefined && Number.isFinite(Number(value));
+    }
+
+    function hasJITData(samples) {
+        return samples.some(sample => isValidMetric(sample?.JITCompilationTimeMs) || isValidMetric(sample?.JITCompiledMethods));
+    }
+
+    function hasClassLoadingData(samples) {
+        return samples.some(sample => isValidMetric(sample?.ClassesLoaded) || isValidMetric(sample?.ClassLoadTimeMs));
+    }
+
     function buildColorMap(processKeys, palette = COLOR_PALETTE) {
         const colorMap = {};
         processKeys.forEach((processKey, index) => {
@@ -202,6 +214,37 @@
         });
     }
 
+    function buildCounterSeries(samples, timestamps, processName, pid, valueSelector) {
+        const observations = samples
+            .filter(sample => sample.Name === processName && sample.PID === pid)
+            .map(sample => ({ timestamp: sample.Timestamp, value: valueSelector(sample) }))
+            .filter(point => isValidMetric(point.value))
+            .map(point => ({ ...point, value: Number(point.value) }))
+            .sort((a, b) => a.timestamp - b.timestamp);
+        const observationByTimestamp = new Map(observations.map(point => [point.timestamp, point.value]));
+        const rateByTimestamp = new Map();
+        let previous = null;
+        observations.forEach(point => {
+            if (previous) {
+                const elapsedSeconds = (point.timestamp - previous.timestamp) / 1000;
+                if (elapsedSeconds > 0 && point.value >= previous.value) {
+                    rateByTimestamp.set(point.timestamp, (point.value - previous.value) / elapsedSeconds);
+                }
+            }
+            previous = point;
+        });
+
+        let displayValue = null;
+        return {
+            observations,
+            cumulative: timestamps.map(timestamp => {
+                if (observationByTimestamp.has(timestamp)) displayValue = observationByTimestamp.get(timestamp);
+                return displayValue;
+            }),
+            rate: timestamps.map(timestamp => rateByTimestamp.has(timestamp) ? rateByTimestamp.get(timestamp) : null)
+        };
+    }
+
     function buildReplayData(samples, timestamps, palette = COLOR_PALETTE) {
         const processKeys = [...new Set(samples.map(s => `${s.Name}|${s.PID}`))];
         const colorMap = buildColorMap(processKeys, palette);
@@ -221,6 +264,9 @@
                 if (!s.RSS || s.RSS <= 0) return null;
                 return s.HeapUsed / s.RSS;
             });
+            const jitTime = buildCounterSeries(samples, timestamps, processName, pid, s => isValidMetric(s.JITCompilationTimeMs) ? s.JITCompilationTimeMs / 1000 : null);
+            const jitActivity = buildCounterSeries(samples, timestamps, processName, pid, s => s.JITCompiledMethods);
+            const classes = buildCounterSeries(samples, timestamps, processName, pid, s => s.ClassesLoaded);
 
             series[processKey] = {
                 processName,
@@ -230,9 +276,17 @@
                 heap,
                 gc,
                 ratio,
+                jitTime: jitTime.cumulative,
+                jitRate: jitActivity.rate,
+                classesLoaded: classes.cumulative,
+                classRate: classes.rate,
                 firstRss: rss.findIndex(value => value !== null),
                 firstGc: gc.findIndex(value => value !== null),
-                firstRatio: ratio.findIndex(value => value !== null)
+                firstRatio: ratio.findIndex(value => value !== null),
+                firstJitTime: jitTime.cumulative.findIndex(value => value !== null),
+                firstJitRate: jitActivity.rate.findIndex(value => value !== null),
+                firstClassesLoaded: classes.cumulative.findIndex(value => value !== null),
+                firstClassRate: classes.rate.findIndex(value => value !== null)
             };
         });
 
@@ -257,9 +311,17 @@
                     heap: def.heap.slice(0, buildEndIndex),
                     gc: def.gc.slice(0, buildEndIndex),
                     ratio: def.ratio.slice(0, buildEndIndex),
+                    jitTime: def.jitTime.slice(0, buildEndIndex),
+                    jitRate: def.jitRate.slice(0, buildEndIndex),
+                    classesLoaded: def.classesLoaded.slice(0, buildEndIndex),
+                    classRate: def.classRate.slice(0, buildEndIndex),
                     firstRss: def.firstRss >= buildEndIndex ? -1 : def.firstRss,
                     firstGc: def.firstGc >= buildEndIndex ? -1 : def.firstGc,
-                    firstRatio: def.firstRatio >= buildEndIndex ? -1 : def.firstRatio
+                    firstRatio: def.firstRatio >= buildEndIndex ? -1 : def.firstRatio,
+                    firstJitTime: def.firstJitTime >= buildEndIndex ? -1 : def.firstJitTime,
+                    firstJitRate: def.firstJitRate >= buildEndIndex ? -1 : def.firstJitRate,
+                    firstClassesLoaded: def.firstClassesLoaded >= buildEndIndex ? -1 : def.firstClassesLoaded,
+                    firstClassRate: def.firstClassRate >= buildEndIndex ? -1 : def.firstClassRate
                 };
             });
         }
@@ -298,6 +360,9 @@
             let maxRss = 0;
             let maxHeap = 0;
             let maxGCTimeSeconds = 0;
+            let finalCompiledMethods = null;
+            let finalJITTimeMs = null;
+            let finalClassesLoaded = null;
             let minTimestamp = Number.POSITIVE_INFINITY;
             let maxTimestamp = 0;
 
@@ -314,6 +379,9 @@
                         maxGCTimeSeconds = gcSeconds;
                     }
                 }
+                if (isValidMetric(sample.JITCompiledMethods)) finalCompiledMethods = Number(sample.JITCompiledMethods);
+                if (isValidMetric(sample.JITCompilationTimeMs)) finalJITTimeMs = Number(sample.JITCompilationTimeMs);
+                if (isValidMetric(sample.ClassesLoaded)) finalClassesLoaded = Number(sample.ClassesLoaded);
                 if (sample.Timestamp && sample.Timestamp < minTimestamp) {
                     minTimestamp = sample.Timestamp;
                 }
@@ -336,7 +404,10 @@
                 maxRss,
                 maxHeap,
                 totalGCTime: maxGCTimeSeconds,
-                durationSeconds
+                durationSeconds,
+                finalCompiledMethods,
+                finalJITTimeMs,
+                finalClassesLoaded
             };
         }
 
@@ -350,6 +421,9 @@
                     maxHeap: entry.maxHeap || 0,
                     totalGCTime: entry.totalGCTime || 0,
                     durationSeconds: entry.durationSeconds || 0,
+                    finalCompiledMethods: entry.finalCompiledMethods,
+                    finalJITTimeMs: entry.finalJITTimeMs,
+                    finalClassesLoaded: entry.finalClassesLoaded,
                     vmFlags: [...new Set(entry.vmFlags || [])],
                     pids: entry.pid ? [entry.pid] : []
                 };
@@ -359,6 +433,9 @@
             byName[name].maxHeap = Math.max(byName[name].maxHeap, entry.maxHeap || 0);
             byName[name].totalGCTime = Math.max(byName[name].totalGCTime, entry.totalGCTime || 0);
             byName[name].durationSeconds = Math.max(byName[name].durationSeconds || 0, entry.durationSeconds || 0);
+            if (entry.finalCompiledMethods !== null) byName[name].finalCompiledMethods = Math.max(byName[name].finalCompiledMethods ?? 0, entry.finalCompiledMethods);
+            if (entry.finalJITTimeMs !== null) byName[name].finalJITTimeMs = Math.max(byName[name].finalJITTimeMs ?? 0, entry.finalJITTimeMs);
+            if (entry.finalClassesLoaded !== null) byName[name].finalClassesLoaded = Math.max(byName[name].finalClassesLoaded ?? 0, entry.finalClassesLoaded);
             if (entry.heapMaxGiB) {
                 const value = Number(entry.heapMaxGiB);
                 if (!Number.isNaN(value)) {
@@ -403,7 +480,16 @@
         const traces = [];
         data.processKeys.forEach(processKey => {
             const def = data.series[processKey];
-            const firstIndex = metric === 'gc' ? def.firstGc : metric === 'ratio' ? def.firstRatio : def.firstRss;
+            const metricMap = {
+                gc: ['firstGc', 'gc'],
+                ratio: ['firstRatio', 'ratio'],
+                jitTime: ['firstJitTime', 'jitTime'],
+                jitRate: ['firstJitRate', 'jitRate'],
+                classesLoaded: ['firstClassesLoaded', 'classesLoaded'],
+                classRate: ['firstClassRate', 'classRate']
+            };
+            const [firstKey, valueKey] = metricMap[metric] || ['firstRss', 'rss'];
+            const firstIndex = def[firstKey];
             if (firstIndex === -1 || frameIndex < firstIndex) return;
             if (metric === 'rss') {
                 traces.push({
@@ -430,7 +516,7 @@
             }
             traces.push({
                 x: frameTimestamps,
-                y: metric === 'gc' ? def.gc.slice(0, frameIndex + 1) : def.ratio.slice(0, frameIndex + 1),
+                y: def[valueKey].slice(0, frameIndex + 1),
                 type: 'scatter',
                 mode: 'lines+markers',
                 name: `${def.processName} PID:${def.pid}`,
@@ -489,7 +575,14 @@
                 HeapUsed: Number(get('heap_used_mb')) || 0,
                 HeapCap: Number(get('heap_capacity_mb')) || 0,
                 GCTime: gcValue !== null && !Number.isNaN(gcValue) ? gcValue * 1000 : null,
-                GCTimeSeconds: gcValue !== null && !Number.isNaN(gcValue) ? gcValue : null
+                GCTimeSeconds: gcValue !== null && !Number.isNaN(gcValue) ? gcValue : null,
+                JITCompiledMethods: get('jit_compiled_methods') === '' ? null : Number(get('jit_compiled_methods')),
+                JITFailedCompilations: get('jit_failed_compilations') === '' ? null : Number(get('jit_failed_compilations')),
+                JITInvalidatedCompilations: get('jit_invalidated_compilations') === '' ? null : Number(get('jit_invalidated_compilations')),
+                JITCompilationTimeMs: get('jit_compilation_time_ms') === '' ? null : Number(get('jit_compilation_time_ms')),
+                ClassesLoaded: get('classes_loaded') === '' ? null : Number(get('classes_loaded')),
+                ClassesUnloaded: get('classes_unloaded') === '' ? null : Number(get('classes_unloaded')),
+                ClassLoadTimeMs: get('class_load_time_ms') === '' ? null : Number(get('class_load_time_ms'))
             };
         });
         return parsed;
@@ -577,6 +670,15 @@
                 scale: 2
             }
         };
+    }
+
+    function getCounterLayout(title, yTitle) {
+        const layout = getGcLayout();
+        return { ...layout, title: window.innerWidth < 768 ? '' : title, yaxis: { ...layout.yaxis, title: yTitle } };
+    }
+
+    function getCounterConfig(filenameBase) {
+        return getGcConfig(filenameBase);
     }
 
     function getRatioLayout() {
@@ -750,6 +852,9 @@
                             <td style="padding: 0.5rem;">${formatValue(item.maxRss, 1)} MB</td>
                             <td style="padding: 0.5rem;">${formatValue(item.maxHeap, 1)} MB</td>
                             <td style="padding: 0.5rem;">${formatValue(item.totalGCTime, 3)} s</td>
+                            <td style="padding: 0.5rem;">${formatValue(item.finalCompiledMethods, 0)}</td>
+                            <td style="padding: 0.5rem;">${item.finalJITTimeMs === null ? 'N/A' : formatValue(item.finalJITTimeMs / 1000, 3) + ' s'}</td>
+                            <td style="padding: 0.5rem;">${formatValue(item.finalClassesLoaded, 0)}</td>
                             <td style="padding: 0.5rem;">${formatValue(item.durationSeconds, 1)} s</td>
                             <td style="padding: 0.5rem;">${flagList}</td>
                         </tr>
@@ -769,6 +874,9 @@
                                     <th style="padding: 0.5rem;">Max RSS (MB)</th>
                                     <th style="padding: 0.5rem;">Max Heap (MB)</th>
                                     <th style="padding: 0.5rem;">Total GC (s)</th>
+                                    <th style="padding: 0.5rem;">Compiled Methods</th>
+                                    <th style="padding: 0.5rem;">JIT Time</th>
+                                    <th style="padding: 0.5rem;">Classes Loaded</th>
                                     <th style="padding: 0.5rem;">Duration (s)</th>
                                     <th style="padding: 0.5rem;">VM Flags</th>
                                 </tr>
@@ -827,11 +935,16 @@
         const baseHasGC = hasGCData(baseSamples);
         const compareHasGC = hasGCData(compareSamples);
         const showGC = baseHasGC && compareHasGC;
+        const showJIT = hasJITData(baseSamples) || hasJITData(compareSamples);
+        const showClasses = hasClassLoadingData(baseSamples) || hasClassLoadingData(compareSamples);
 
         const storedMode = localStorage.getItem(compareModeStorageKey) || 'split';
         const compareMode = storedMode === 'side' ? 'side' : 'split';
         const isSplitMode = compareMode === 'split';
         const splitLabel = `${baseLabel} vs ${compareLabel} (Split View)`;
+        const counterPanel = (title, metrics) => isSplitMode
+            ? `<div class="chart-container"><h4>${title}</h4>${metrics.map(([id]) => `<div id="compare-${id}" style="width:100%;height:400px"></div>`).join('')}</div>`
+            : `<div class="compare-grid">${[baseLabel, compareLabel].map((label, index) => `<div class="chart-container"><h4>${title}: ${label}</h4>${metrics.map(([id]) => `<div id="compare-${index === 0 ? 'current' : 'other'}-${id}" style="width:100%;height:400px"></div>`).join('')}</div>`).join('')}</div>`;
 
         compareSection.innerHTML = `
             <div class="compare-header">
@@ -946,6 +1059,8 @@
                 </div>
                 `}
             </div>
+            ${showJIT ? counterPanel('JIT Compilation', [['jit-time'], ['jit-rate']]) : ''}
+            ${showClasses ? counterPanel('Class Loading', [['classes-loaded'], ['class-rate']]) : ''}
         `;
 
         compareSection.style.display = 'block';
@@ -1191,6 +1306,35 @@
                     tasks.push(Plotly.react('compare-other-gc', applyVisibilityToTraces('compare-other-gc', buildMetricTraces(compareData, timestamps, frameIndex, 'gc', compareStyle, compareElapsed)), sideGcLayout, getGcConfig(gcFilenameBase)));
                 }
             }
+            const renderCounterMetric = (id, metric, title, yTitle) => {
+                const layout = getCounterLayout(title, yTitle);
+                layout.xaxis = {
+                    ...layout.xaxis,
+                    title: 'Elapsed (s)',
+                    tickformat: null,
+                    type: 'linear',
+                    tickvals: isSplitMode ? tickVals : undefined,
+                    ticktext: isSplitMode ? tickText : undefined
+                };
+                if (isSplitMode) {
+                    const traces = [
+                        ...buildMetricTraces(baseData, timestamps, frameIndex, metric, baseStyle, elapsedSeconds),
+                        ...buildMetricTraces(compareData, timestamps, frameIndex, metric, compareStyle, compareElapsed)
+                    ];
+                    tasks.push(Plotly.react(`compare-${id}`, applyVisibilityToTraces(`compare-${id}`, traces), layout, getCounterConfig(`compare-${metric}`)));
+                } else {
+                    tasks.push(Plotly.react(`compare-current-${id}`, applyVisibilityToTraces(`compare-current-${id}`, buildMetricTraces(baseData, timestamps, frameIndex, metric, baseStyle, elapsedSeconds)), layout, getCounterConfig(`compare-current-${metric}`)));
+                    tasks.push(Plotly.react(`compare-other-${id}`, applyVisibilityToTraces(`compare-other-${id}`, buildMetricTraces(compareData, timestamps, frameIndex, metric, compareStyle, elapsedSeconds)), layout, getCounterConfig(`compare-other-${metric}`)));
+                }
+            };
+            if (showJIT) {
+                renderCounterMetric('jit-time', 'jitTime', 'Cumulative JIT Compilation Time', 'Compilation Time (s)');
+                renderCounterMetric('jit-rate', 'jitRate', 'JIT Compilation Activity', 'Compiled Methods / s');
+            }
+            if (showClasses) {
+                renderCounterMetric('classes-loaded', 'classesLoaded', 'Cumulative Classes Loaded', 'Classes Loaded');
+                renderCounterMetric('class-rate', 'classRate', 'Class Loading Activity', 'Classes / s');
+            }
             return Promise.all(tasks).then(() => {
                 const isTotalSplit = (name) => name === 'Total RSS Memory' || name === 'Compare Total RSS Memory';
                 const isTotalBase = (name) => name === 'Total RSS Memory';
@@ -1211,6 +1355,15 @@
                         attachLegendVisibilityHandlers('compare-other-gc');
                     }
                 }
+                const counterIds = ['jit-time', 'jit-rate', 'classes-loaded', 'class-rate'];
+                counterIds.forEach(id => {
+                    if (isSplitMode) {
+                        if (document.getElementById(`compare-${id}`)) attachLegendVisibilityHandlers(`compare-${id}`);
+                    } else {
+                        if (document.getElementById(`compare-current-${id}`)) attachLegendVisibilityHandlers(`compare-current-${id}`);
+                        if (document.getElementById(`compare-other-${id}`)) attachLegendVisibilityHandlers(`compare-other-${id}`);
+                    }
+                });
             });
         }
 
@@ -1304,11 +1457,14 @@
         attachLegendVisibilityHandlers,
         hasGCData,
         hasRatioData,
+        hasJITData,
+        hasClassLoadingData,
         buildColorMap,
         getMedianDelta,
         buildTotalRssSeries,
         buildForwardFilledSeries,
         buildExactSeries,
+        buildCounterSeries,
         buildReplayData,
         buildMetricTraces,
         parseCsvText,
@@ -1317,6 +1473,8 @@
         normalizeCompareSamples,
         getGcLayout,
         getGcConfig,
+        getCounterLayout,
+        getCounterConfig,
         getRatioLayout,
         getRatioConfig,
         getMemoryLayout,

--- a/frontend/public/compare.html
+++ b/frontend/public/compare.html
@@ -205,7 +205,7 @@
     <div class="container">
         <header>
             <h1>Compare JSON Runs</h1>
-            <div class="meta">Upload two JSON files to compare memory, GC, and process configuration.</div>
+            <div class="meta">Upload two JSON files to compare memory, GC, JIT, class loading, and process configuration.</div>
             <a class="back-link back-home-link" href="https://process-watcher.web.app">← Back to Home</a>
         </header>
 

--- a/frontend/public/replay.html
+++ b/frontend/public/replay.html
@@ -174,7 +174,7 @@
     <div class="container">
         <header>
             <h1>Replay JSON Run</h1>
-            <div class="meta">Upload a JSON export to replay memory and GC panels.</div>
+            <div class="meta">Upload a JSON export to replay memory, GC, JIT, and class-loading panels.</div>
             <a class="back-link back-home-link" href="https://process-watcher.web.app">← Back to Home</a>
         </header>
 

--- a/frontend/public/replay.js
+++ b/frontend/public/replay.js
@@ -2,6 +2,8 @@
     const {
         parseJsonText,
         hasGCData,
+        hasJITData,
+        hasClassLoadingData,
         buildReplayData,
         buildMetricTraces,
         applyVisibilityToTraces,
@@ -10,6 +12,8 @@
         getMemoryConfig,
         getGcLayout,
         getGcConfig,
+        getCounterLayout,
+        getCounterConfig,
         visibilityStore
     } = window.BpwCompareShared || {};
 
@@ -35,6 +39,8 @@
         const chartTimestamps = data.timestamps || timestamps;
         const elapsedSeconds = chartTimestamps.map(ts => Math.max(0, (ts - chartTimestamps[0]) / 1000));
         const showGC = hasGCData(samples);
+        const showJIT = hasJITData(samples);
+        const showClasses = hasClassLoadingData(samples);
 
         section.innerHTML = `
             <div class="replay-controls" id="single-replay-controls">
@@ -83,6 +89,16 @@
                 </div>
             </div>
             ` : ''}
+            ${showJIT ? `
+            <div class="chart-container"><h4>JIT Compilation</h4>
+                <div id="single-jit-time" style="width:100%;height:400px"></div>
+                <div id="single-jit-rate" style="width:100%;height:400px"></div>
+            </div>` : ''}
+            ${showClasses ? `
+            <div class="chart-container"><h4>Class Loading</h4>
+                <div id="single-classes-loaded" style="width:100%;height:400px"></div>
+                <div id="single-class-rate" style="width:100%;height:400px"></div>
+            </div>` : ''}
         `;
 
         section.style.display = 'block';
@@ -233,6 +249,20 @@
                 }, elapsedSeconds);
                 tasks.push(Plotly.react('single-gc', applyVisibilityToTraces('single-gc', gcTraces), gcLayout, getGcConfig('build-replay-gc')));
             }
+            const counterChart = (id, metric, title, yTitle) => {
+                const layout = getCounterLayout(title, yTitle);
+                layout.xaxis = { ...layout.xaxis, title: 'Elapsed (s)', tickformat: null, type: 'linear' };
+                const traces = buildMetricTraces(data, chartTimestamps, frameIndex, metric, {}, elapsedSeconds);
+                tasks.push(Plotly.react(id, applyVisibilityToTraces(id, traces), layout, getCounterConfig(`build-replay-${metric}`)));
+            };
+            if (showJIT) {
+                counterChart('single-jit-time', 'jitTime', 'Cumulative JIT Compilation Time', 'Compilation Time (s)');
+                counterChart('single-jit-rate', 'jitRate', 'JIT Compilation Activity', 'Compiled Methods / s');
+            }
+            if (showClasses) {
+                counterChart('single-classes-loaded', 'classesLoaded', 'Cumulative Classes Loaded', 'Classes Loaded');
+                counterChart('single-class-rate', 'classRate', 'Class Loading Activity', 'Classes / s');
+            }
 
             return Promise.all(tasks).then(() => {
                 setupSingleReplayFilters();
@@ -240,6 +270,8 @@
                 if (showGC) {
                     attachLegendVisibilityHandlers('single-gc');
                 }
+                ['single-jit-time', 'single-jit-rate', 'single-classes-loaded', 'single-class-rate']
+                    .forEach(id => { if (document.getElementById(id)) attachLegendVisibilityHandlers(id); });
             });
         }
 

--- a/frontend/public/runs/[runId].html
+++ b/frontend/public/runs/[runId].html
@@ -464,6 +464,8 @@
             attachLegendVisibilityHandlers,
             hasGCData,
             hasRatioData,
+            hasJITData,
+            hasClassLoadingData,
             buildColorMap,
             buildTotalRssSeries,
             buildForwardFilledSeries,
@@ -564,6 +566,9 @@
                 let maxRss = 0;
                 let maxHeap = 0;
                 let maxGCTimeSeconds = 0;
+                let finalCompiledMethods = null;
+                let finalJITTimeMs = null;
+                let finalClassesLoaded = null;
                 
                 processSamples.forEach(sample => {
                     if (sample.RSS && sample.RSS > maxRss) {
@@ -579,12 +584,18 @@
                             maxGCTimeSeconds = gcSeconds;
                         }
                     }
+                    if (Number.isFinite(Number(sample.JITCompiledMethods))) finalCompiledMethods = Number(sample.JITCompiledMethods);
+                    if (Number.isFinite(Number(sample.JITCompilationTimeMs))) finalJITTimeMs = Number(sample.JITCompilationTimeMs);
+                    if (Number.isFinite(Number(sample.ClassesLoaded))) finalClassesLoaded = Number(sample.ClassesLoaded);
                 });
                 
                 processMetrics[pid] = {
                     maxRss: maxRss,
                     maxHeap: maxHeap,
-                    totalGCTime: maxGCTimeSeconds
+                    totalGCTime: maxGCTimeSeconds,
+                    finalCompiledMethods,
+                    finalJITTimeMs,
+                    finalClassesLoaded
                 };
                 if (maxHeap > maxHeapAllProcesses) {
                     maxHeapAllProcesses = maxHeap;
@@ -647,6 +658,9 @@
                     processInfoHtml += `<div class="process-metric"><strong>Max RSS</strong><span>${metrics.maxRss > 0 ? metrics.maxRss.toFixed(1) + ' MB' : 'N/A'}</span></div>`;
                     processInfoHtml += `<div class="process-metric"><strong>Max Heap</strong><span>${metrics.maxHeap > 0 ? metrics.maxHeap.toFixed(1) + ' MB' : 'N/A'}</span></div>`;
                     processInfoHtml += `<div class="process-metric"><strong>Total GC Time</strong><span>${metrics.totalGCTime > 0 ? metrics.totalGCTime.toFixed(3) + ' s' : 'N/A'}</span></div>`;
+                    processInfoHtml += `<div class="process-metric"><strong>Compiled Methods</strong><span>${metrics.finalCompiledMethods ?? 'N/A'}</span></div>`;
+                    processInfoHtml += `<div class="process-metric"><strong>JIT Time</strong><span>${metrics.finalJITTimeMs !== null ? (metrics.finalJITTimeMs / 1000).toFixed(3) + ' s' : 'N/A'}</span></div>`;
+                    processInfoHtml += `<div class="process-metric"><strong>Classes Loaded</strong><span>${metrics.finalClassesLoaded ?? 'N/A'}</span></div>`;
                     processInfoHtml += '</div>';
                     
                     if (vmFlags.length > 0) {
@@ -863,6 +877,16 @@
                     </div>
                 </div>
                 ` : ''}
+                ${hasJITData(samples) ? `
+                <div class="chart-container"><h3>JIT Compilation</h3>
+                    <div id="jit-time-chart" style="width:100%;height:450px"></div>
+                    <div id="jit-rate-chart" style="width:100%;height:450px"></div>
+                </div>` : ''}
+                ${hasClassLoadingData(samples) ? `
+                <div class="chart-container"><h3>Class Loading</h3>
+                    <div id="classes-loaded-chart" style="width:100%;height:450px"></div>
+                    <div id="class-rate-chart" style="width:100%;height:450px"></div>
+                </div>` : ''}
 
                 ${processInfoHtml}
 
@@ -887,6 +911,7 @@
                 if (shouldShowRssHeapRatioChart(samples)) {
                     renderRssHeapRatioChart(samples);
                 }
+                renderJvmCounterCharts(samples);
                 if (isFinished === true) {
                     setupCompareControls(samples);
                     initReplay(samples);
@@ -1992,6 +2017,25 @@
             });
         }
 
+        function renderJvmCounterCharts(samples) {
+            if (!hasJITData(samples) && !hasClassLoadingData(samples)) return;
+            const timestamps = [...new Set(samples.map(s => s.Timestamp))].sort((a, b) => a - b);
+            const data = buildReplayData(samples, timestamps);
+            const frame = Math.max(0, data.timestamps.length - 1);
+            const charts = [
+                ['jit-time-chart', 'jitTime', 'Cumulative JIT Compilation Time', 'Compilation Time (s)'],
+                ['jit-rate-chart', 'jitRate', 'JIT Compilation Activity', 'Compiled Methods / s'],
+                ['classes-loaded-chart', 'classesLoaded', 'Cumulative Classes Loaded', 'Classes Loaded'],
+                ['class-rate-chart', 'classRate', 'Class Loading Activity', 'Classes / s']
+            ];
+            charts.forEach(([id, metric, title, yTitle]) => {
+                if (!document.getElementById(id)) return;
+                const traces = buildMetricTraces(data, data.timestamps, frame, metric, {});
+                Plotly.newPlot(id, applyVisibilityToTraces(id, traces), CompareShared.getCounterLayout(title, yTitle), CompareShared.getCounterConfig(`build-monitor-${metric}-${runId}`));
+                attachLegendVisibilityHandlers(id);
+            });
+        }
+
         async function downloadChart(format) {
             try {
                 const chart = document.getElementById('chart');
@@ -2093,9 +2137,7 @@
                 const samples = window.currentSamples || [];
                 if (!samples.length) return;
                 const hasGC = hasGCData(samples);
-                const header = hasGC ? 
-                    ['timestamp','elapsed_time','pid','name','rss_mb','heap_used_mb','heap_capacity_mb','gc_time_s'] :
-                    ['timestamp','elapsed_time','pid','name','rss_mb','heap_used_mb','heap_capacity_mb'];
+                const header = ['timestamp','elapsed_time','pid','name','rss_mb','heap_used_mb','heap_capacity_mb','gc_time_s','jit_compiled_methods','jit_failed_compilations','jit_invalidated_compilations','jit_compilation_time_ms','classes_loaded','classes_unloaded','class_load_time_ms'];
                 const rows = samples.map(s => {
                     const baseRow = [
                         s.Timestamp,
@@ -2106,10 +2148,8 @@
                         s.HeapUsed,
                         s.HeapCap
                     ];
-                    if (hasGC) {
-                        // Convert from milliseconds (stored in DB) to seconds (for display)
-                        baseRow.push(s.GCTime ? (s.GCTime / 1000).toFixed(3) : 0);
-                    }
+                    baseRow.push(s.GCTime !== null && s.GCTime !== undefined ? (s.GCTime / 1000).toFixed(3) : null);
+                    baseRow.push(s.JITCompiledMethods, s.JITFailedCompilations, s.JITInvalidatedCompilations, s.JITCompilationTimeMs, s.ClassesLoaded, s.ClassesUnloaded, s.ClassLoadTimeMs);
                     return baseRow;
                 });
                 const csv = [header.join(','), ...rows.map(r => r.map(escapeCsv).join(','))].join('\n');

--- a/monitor_with_backend.sh
+++ b/monitor_with_backend.sh
@@ -51,7 +51,7 @@ fi
 
 # Initialize log file with header (GC always enabled)
 echo "Session started: $(date '+%Y-%m-%d %H:%M:%S')" > "$LOG_FILE"
-echo "Elapsed_Time | PID | Name | Heap_Used_MB | Heap_Capacity_MB | RSS_MB | GC_Time_S" >> "$LOG_FILE"
+echo "Elapsed_Time | PID | Name | Heap_Used_MB | Heap_Capacity_MB | RSS_MB | GC_Time_S | JIT_Compiled | JIT_Failed | JIT_Invalid | JIT_Time_S | Classes_Loaded | Classes_Unloaded | Class_Time_S" >> "$LOG_FILE"
 
 # Process info file for VM flags (used by cleanup to include in JSON artifact)
 PROCESS_INFO_FILE="${LOG_FILE%.log}.process_info"
@@ -103,6 +103,42 @@ process_exists() {
         return 0
     fi
     return 1
+}
+
+# Print requested jstat values in header order, using N/A for unavailable columns.
+jstat_named_values() {
+    local mode="$1"
+    local pid="$2"
+    shift 2
+    local output
+    output=$(jstat "$mode" "$pid" 2>/dev/null) || output=""
+    if [ -z "$output" ]; then
+        printf 'N/A'
+        printf '|N/A' $(seq 2 "$#")
+        return 1
+    fi
+
+    local header values
+    header=$(printf '%s\n' "$output" | awk 'NF { print; exit }')
+    values=$(printf '%s\n' "$output" | awk 'NF { line=$0 } END { print line }')
+    awk -v requested="$*" '
+        NR == 1 {
+            for (i = 1; i <= NF; i++) column[$i] = i
+            next
+        }
+        {
+            count = split(requested, names, " ")
+            for (i = 1; i <= count; i++) {
+                if (i > 1) printf "|"
+                columnIndex = column[names[i]]
+                if (columnIndex > 0 && columnIndex <= NF) printf "%s", $columnIndex
+                else printf "N/A"
+            }
+        }
+    ' <<EOF
+$header
+$values
+EOF
 }
 
 seen_pids=""
@@ -374,12 +410,19 @@ send_to_backend() {
     local heap_cap="$5"
     local rss="$6"
     local gc_time="${7:-}"
+    local jit_compiled="${8:-N/A}"
+    local jit_failed="${9:-N/A}"
+    local jit_invalid="${10:-N/A}"
+    local jit_time="${11:-N/A}"
+    local classes_loaded="${12:-N/A}"
+    local classes_unloaded="${13:-N/A}"
+    local class_time="${14:-N/A}"
     
     log_script "send_to_backend called: timestamp=$timestamp, pid=$pid, name=$name, heap_used=$heap_used, heap_cap=$heap_cap, rss=$rss, gc_time=$gc_time"
     
     # Prepare data in the format expected by our backend
     if [ -n "$gc_time" ]; then
-        local data_line="$timestamp | $pid | $name | $heap_used | $heap_cap | $rss | $gc_time"
+        local data_line="$timestamp | $pid | $name | $heap_used | $heap_cap | $rss | $gc_time | $jit_compiled | $jit_failed | $jit_invalid | $jit_time | $classes_loaded | $classes_unloaded | $class_time"
     else
         local data_line="$timestamp | $pid | $name | $heap_used | $heap_cap | $rss"
     fi
@@ -706,14 +749,18 @@ while true; do
         fi
         {
           GC_LINE=$(jstat -gc "$PID" 2>/dev/null | tail -n 1)
+          JIT_VALUES=$(jstat_named_values -compiler "$PID" Compiled Failed Invalid Time)
+          CLASS_VALUES=$(jstat_named_values -class "$PID" Loaded Unloaded Time)
+          IFS='|' read -r JIT_COMPILED JIT_FAILED JIT_INVALID JIT_TIME_S <<< "$JIT_VALUES"
+          IFS='|' read -r CLASSES_LOADED CLASSES_UNLOADED CLASS_TIME_S <<< "$CLASS_VALUES"
           RSS_KB=$(ps -o rss= -p "$PID" 2>/dev/null | tr -d ' ')
           [[ -z "$RSS_KB" ]] && continue
           RSS_MB=$(awk "BEGIN { printf \"%.1f\", $RSS_KB / 1024 }")
 
           if [[ -z "$GC_LINE" ]]; then
-            echo "$TIMESTAMP | $PID | $NAME | N/A | N/A | ${RSS_MB}MB | N/A" >> "$LOG_FILE"
+            echo "$TIMESTAMP | $PID | $NAME | N/A | N/A | ${RSS_MB}MB | N/A | $JIT_COMPILED | $JIT_FAILED | $JIT_INVALID | $JIT_TIME_S | $CLASSES_LOADED | $CLASSES_UNLOADED | $CLASS_TIME_S" >> "$LOG_FILE"
             # Store process data for batch sending
-            process_data+=("$TIMESTAMP|$PID|$NAME|0|0|${RSS_MB}MB|N/A")
+            process_data+=("$TIMESTAMP|$PID|$NAME|0|0|${RSS_MB}MB|N/A|$JIT_COMPILED|$JIT_FAILED|$JIT_INVALID|$JIT_TIME_S|$CLASSES_LOADED|$CLASSES_UNLOADED|$CLASS_TIME_S")
           else
             EC=$(echo "$GC_LINE" | awk '{print $5}')
             EU=$(echo "$GC_LINE" | awk '{print $6}')
@@ -736,9 +783,9 @@ while true; do
             else
               GC_TIME_S="N/A"
             fi
-            echo "$TIMESTAMP | $PID | $NAME | ${HEAP_USED_MB}MB | ${HEAP_CAP_MB}MB | ${RSS_MB}MB | ${GC_TIME_S}s" >> "$LOG_FILE"
+            echo "$TIMESTAMP | $PID | $NAME | ${HEAP_USED_MB}MB | ${HEAP_CAP_MB}MB | ${RSS_MB}MB | ${GC_TIME_S}s | $JIT_COMPILED | $JIT_FAILED | $JIT_INVALID | $JIT_TIME_S | $CLASSES_LOADED | $CLASSES_UNLOADED | $CLASS_TIME_S" >> "$LOG_FILE"
             # Store process data for batch sending
-            process_data+=("$TIMESTAMP|$PID|$NAME|${HEAP_USED_MB}MB|${HEAP_CAP_MB}MB|${RSS_MB}MB|${GC_TIME_S}s")
+            process_data+=("$TIMESTAMP|$PID|$NAME|${HEAP_USED_MB}MB|${HEAP_CAP_MB}MB|${RSS_MB}MB|${GC_TIME_S}s|$JIT_COMPILED|$JIT_FAILED|$JIT_INVALID|$JIT_TIME_S|$CLASSES_LOADED|$CLASSES_UNLOADED|$CLASS_TIME_S")
           fi
         } || { 
           log_script "ERROR: Failed to process memory data for PID $PID ($NAME) at $TIMESTAMP"
@@ -769,9 +816,9 @@ while true; do
     for data_line in "${process_data[@]}"; do
       sends_attempted=$((sends_attempted + 1))
       log_script "Sending data line: '$data_line'"
-      IFS='|' read -r ts pid name heap_used heap_cap rss gc_time <<< "$data_line"
+      IFS='|' read -r ts pid name heap_used heap_cap rss gc_time jit_compiled jit_failed jit_invalid jit_time classes_loaded classes_unloaded class_time <<< "$data_line"
       log_script "Calling send_to_backend with GC data for PID $pid"
-      if send_to_backend "$ts" "$pid" "$name" "${heap_used}MB" "${heap_cap}MB" "${rss}MB" "$gc_time"; then
+      if send_to_backend "$ts" "$pid" "$name" "$heap_used" "$heap_cap" "$rss" "$gc_time" "$jit_compiled" "$jit_failed" "$jit_invalid" "$jit_time" "$classes_loaded" "$classes_unloaded" "$class_time"; then
         sends_succeeded=$((sends_succeeded + 1))
         log_script "send_to_backend succeeded for PID $pid"
       else

--- a/scripts/benchmark-jstat-metrics.sh
+++ b/scripts/benchmark-jstat-metrics.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+PID="${1:-}"
+ITERATIONS="${ITERATIONS:-20}"
+
+if [ -z "$PID" ]; then
+  echo "Usage: $0 <java-pid>" >&2
+  exit 1
+fi
+
+measure() {
+  local label="$1"
+  shift
+  local start end
+  start=$(date +%s%N)
+  for ((i = 0; i < ITERATIONS; i++)); do
+    "$@" >/dev/null 2>&1 || true
+  done
+  end=$(date +%s%N)
+  awk -v label="$label" -v elapsed="$((end - start))" -v count="$ITERATIONS" 'BEGIN { printf "%s: %.2f ms/sample over %d iterations\n", label, elapsed / count / 1000000, count }'
+}
+
+measure "memory+gc" jstat -gc "$PID"
+measure "jit" jstat -compiler "$PID"
+measure "class-loading" jstat -class "$PID"

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -2,7 +2,6 @@ import { exec, execSync } from 'child_process';
 import { promisify } from 'util';
 import * as fs from 'fs';
 import * as path from 'path';
-import { DefaultArtifactClient } from '@actions/artifact';
 import * as core from '@actions/core';
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
@@ -27,8 +26,8 @@ function parseLogFile(logFile: string): { processes: Map<string, ProcessData>, t
     // Skip header lines
     lines.slice(2).forEach(line => {
         const parts = line.trim().split('|').map(p => p.trim());
-        // Support both 6 columns (without GC) and 7 columns (with GC)
-        if (parts.length !== 6 && parts.length !== 7) return;
+        // Support historical 6/7-column records and extended JVM metric records.
+        if (parts.length !== 6 && parts.length !== 7 && parts.length !== 14) return;
 
         const [timestamp, pid, name, heapUsed, heapCap, rss, gcTime] = parts;
         const rssValue = parseFloat(rss.replace('MB', ''));
@@ -48,7 +47,7 @@ function parseLogFile(logFile: string): { processes: Map<string, ProcessData>, t
         processData.heapCap.push(heapCapValue);
         
         // Parse GC time if available (7th column)
-        if (parts.length === 7 && gcTime) {
+        if (parts.length >= 7 && gcTime) {
             hasGcData = true;
             // Remove 's' suffix if present and parse as float
             const gcTimeValue = parseFloat(gcTime.replace('s', ''));
@@ -71,15 +70,13 @@ function parseLogFile(logFile: string): { processes: Map<string, ProcessData>, t
 function generateCsvReport(logFile: string, outputFile: string, hasGcData: boolean): void {
     const lines = fs.readFileSync(logFile, 'utf8').split('\n');
     const dataLines = lines.slice(2).filter(line => line.trim().length > 0);
-    const header = hasGcData
-        ? ['elapsed_time', 'pid', 'name', 'heap_used_mb', 'heap_capacity_mb', 'rss_mb', 'gc_time_s']
-        : ['elapsed_time', 'pid', 'name', 'heap_used_mb', 'heap_capacity_mb', 'rss_mb'];
+    const header = ['elapsed_time', 'pid', 'name', 'heap_used_mb', 'heap_capacity_mb', 'rss_mb', 'gc_time_s', 'jit_compiled_methods', 'jit_failed_compilations', 'jit_invalidated_compilations', 'jit_compilation_time_s', 'classes_loaded', 'classes_unloaded', 'class_load_time_s'];
     const rows = [header.join(',')];
 
     dataLines.forEach(line => {
         const parts = line.trim().split('|').map(p => p.trim());
-        if (parts.length !== 6 && parts.length !== 7) return;
-        const [timestamp, pid, name, heapUsed, heapCap, rss, gcTime] = parts;
+        if (parts.length !== 6 && parts.length !== 7 && parts.length !== 14) return;
+        const [timestamp, pid, name, heapUsed, heapCap, rss, gcTime, ...optionalMetrics] = parts;
         const baseRow = [
             timestamp,
             pid,
@@ -88,9 +85,8 @@ function generateCsvReport(logFile: string, outputFile: string, hasGcData: boole
             heapCap.replace('MB', ''),
             rss.replace('MB', '')
         ];
-        if (parts.length === 7 && hasGcData) {
-            baseRow.push(gcTime.replace('s', '').replace('N/A', '0'));
-        }
+        baseRow.push(parts.length >= 7 && hasGcData ? gcTime.replace('s', '').replace('N/A', '') : '');
+        baseRow.push(...Array.from({ length: 7 }, (_, index) => optionalMetrics[index]?.replace('N/A', '') ?? ''));
         rows.push(baseRow.join(','));
     });
 
@@ -974,6 +970,7 @@ async function run() {
         
         if (shouldUpload) {
             try {
+                const { DefaultArtifactClient } = await import('@actions/artifact');
                 const artifactClient = new DefaultArtifactClient();
                 // Create stable artifact name using job name and run attempt
                 const jobName = process.env.GITHUB_JOB || 'default';

--- a/src/lib/report.ts
+++ b/src/lib/report.ts
@@ -68,22 +68,38 @@ export function generateJsonReport(logFile: string, outputFile: string, hasGcDat
         HeapCap: number;
         GCTime: number | null;
         GCTimeSeconds: number | null;
+        JITCompiledMethods: number | null;
+        JITFailedCompilations: number | null;
+        JITInvalidatedCompilations: number | null;
+        JITCompilationTimeMs: number | null;
+        ClassesLoaded: number | null;
+        ClassesUnloaded: number | null;
+        ClassLoadTimeMs: number | null;
     }> = [];
     const processInfoFromFile = loadProcessInfoFromFile(logFile);
     const processInfo: Record<string, { name: string; vm_flags: string[] }> = {};
 
     dataLines.forEach(line => {
         const parts = line.trim().split('|').map(p => p.trim());
-        if (parts.length !== 6 && parts.length !== 7) return;
-        const [timestamp, pid, name, heapUsed, heapCap, rss, gcTime] = parts;
+        if (parts.length !== 6 && parts.length !== 7 && parts.length !== 14) return;
+        const [timestamp, pid, name, heapUsed, heapCap, rss, gcTime, jitCompiled, jitFailed, jitInvalid, jitTime, classesLoaded, classesUnloaded, classTime] = parts;
         const elapsedSeconds = parseTimestampSeconds(timestamp);
         const rssValue = parseFloat(rss.replace('MB', ''));
         const heapUsedValue = parseFloat(heapUsed.replace('MB', ''));
         const heapCapValue = parseFloat(heapCap.replace('MB', ''));
-        const gcSeconds = parts.length === 7 && hasGcData
-            ? parseFloat(gcTime.replace('s', '').replace('N/A', '0'))
+        const gcSeconds = parts.length >= 7 && hasGcData
+            ? parseFloat(gcTime.replace('s', ''))
             : NaN;
         const gcSecondsValue = Number.isNaN(gcSeconds) ? null : gcSeconds;
+        const optionalNumber = (value: string | undefined): number | null => {
+            if (!value || value === 'N/A') return null;
+            const parsed = Number(value.replace(/s$/, ''));
+            return Number.isFinite(parsed) ? parsed : null;
+        };
+        const optionalMillis = (value: string | undefined): number | null => {
+            const seconds = optionalNumber(value);
+            return seconds === null ? null : seconds * 1000;
+        };
 
         samples.push({
             Timestamp: Math.max(0, elapsedSeconds * 1000),
@@ -94,7 +110,14 @@ export function generateJsonReport(logFile: string, outputFile: string, hasGcDat
             HeapUsed: Number.isNaN(heapUsedValue) ? 0 : heapUsedValue,
             HeapCap: Number.isNaN(heapCapValue) ? 0 : heapCapValue,
             GCTime: gcSecondsValue !== null ? gcSecondsValue * 1000 : null,
-            GCTimeSeconds: gcSecondsValue
+            GCTimeSeconds: gcSecondsValue,
+            JITCompiledMethods: optionalNumber(jitCompiled),
+            JITFailedCompilations: optionalNumber(jitFailed),
+            JITInvalidatedCompilations: optionalNumber(jitInvalid),
+            JITCompilationTimeMs: optionalMillis(jitTime),
+            ClassesLoaded: optionalNumber(classesLoaded),
+            ClassesUnloaded: optionalNumber(classesUnloaded),
+            ClassLoadTimeMs: optionalMillis(classTime)
         });
 
         if (!processInfo[pid]) {


### PR DESCRIPTION
## Summary
- use BigQuery nullable integer values for optional JIT/class metric columns
- update exporter tests to preserve null vs populated metric values

## Verification
- go test ./... from backend module