### PR TITLE
fix: export nullable JIT metrics to BigQuery

### DIFF
--- a/backend/internal/bigqueryexport/export.go
+++ b/backend/internal/bigqueryexport/export.go
@@ -57,31 +57,30 @@ func (e *Exporter) Close() error {
 
 // sampleRow matches schema in schema/bigquery_build_process_samples.sql
 type sampleRow struct {
-	RunID                      string    `bigquery:"run_id"`
-	SampleTimestamp            time.Time `bigquery:"sample_timestamp"`
-	ElapsedTime                int64     `bigquery:"elapsed_time"`
-	PID                        string    `bigquery:"pid"`
-	Name                       string    `bigquery:"name"`
-	HeapUsedMB                 int64     `bigquery:"heap_used"`
-	HeapCapMB                  int64     `bigquery:"heap_cap"`
-	RSSMB                      int64     `bigquery:"rss"`
-	GCTimeMS                   int64     `bigquery:"gc_time"`
-	JITCompiledMethods         *int64    `bigquery:"jit_compiled_methods"`
-	JITFailedCompilations      *int64    `bigquery:"jit_failed_compilations"`
-	JITInvalidatedCompilations *int64    `bigquery:"jit_invalidated_compilations"`
-	JITCompilationTimeMs       *int64    `bigquery:"jit_compilation_time_ms"`
-	ClassesLoaded              *int64    `bigquery:"classes_loaded"`
-	ClassesUnloaded            *int64    `bigquery:"classes_unloaded"`
-	ClassLoadTimeMs            *int64    `bigquery:"class_load_time_ms"`
-	RunFinishedAt              time.Time `bigquery:"run_finished_at"`
+	RunID                      string             `bigquery:"run_id"`
+	SampleTimestamp            time.Time          `bigquery:"sample_timestamp"`
+	ElapsedTime                int64              `bigquery:"elapsed_time"`
+	PID                        string             `bigquery:"pid"`
+	Name                       string             `bigquery:"name"`
+	HeapUsedMB                 int64              `bigquery:"heap_used"`
+	HeapCapMB                  int64              `bigquery:"heap_cap"`
+	RSSMB                      int64              `bigquery:"rss"`
+	GCTimeMS                   int64              `bigquery:"gc_time"`
+	JITCompiledMethods         bigquery.NullInt64 `bigquery:"jit_compiled_methods"`
+	JITFailedCompilations      bigquery.NullInt64 `bigquery:"jit_failed_compilations"`
+	JITInvalidatedCompilations bigquery.NullInt64 `bigquery:"jit_invalidated_compilations"`
+	JITCompilationTimeMs       bigquery.NullInt64 `bigquery:"jit_compilation_time_ms"`
+	ClassesLoaded              bigquery.NullInt64 `bigquery:"classes_loaded"`
+	ClassesUnloaded            bigquery.NullInt64 `bigquery:"classes_unloaded"`
+	ClassLoadTimeMs            bigquery.NullInt64 `bigquery:"class_load_time_ms"`
+	RunFinishedAt              time.Time          `bigquery:"run_finished_at"`
 }
 
-func optionalInt64(value *int) *int64 {
+func optionalInt64(value *int) bigquery.NullInt64 {
 	if value == nil {
-		return nil
+		return bigquery.NullInt64{}
 	}
-	converted := int64(*value)
-	return &converted
+	return bigquery.NullInt64{Int64: int64(*value), Valid: true}
 }
 
 // ExportRun inserts all samples for a finished run. Errors do not rollback Firestore; callers log and continue.

--- a/backend/internal/bigqueryexport/export_test.go
+++ b/backend/internal/bigqueryexport/export_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/cdsap/build-process-watcher/backend/internal/models"
 )
 
@@ -70,20 +71,22 @@ func TestStableInsertID(t *testing.T) {
 }
 
 func TestOptionalInt64(t *testing.T) {
-	if optionalInt64(nil) != nil {
-		t.Fatal("nil metric must remain nil")
+	if got := optionalInt64(nil); got.Valid {
+		t.Fatalf("nil metric must remain invalid, got %+v", got)
 	}
 	value := 42
 	converted := optionalInt64(&value)
-	if converted == nil || *converted != 42 {
+	if !converted.Valid || converted.Int64 != 42 {
 		t.Fatalf("unexpected conversion: %v", converted)
 	}
 }
 
 func TestSampleRowOptionalMetricTags(t *testing.T) {
-	value := int64(1)
-	row := sampleRow{JITCompiledMethods: &value, ClassesLoaded: nil}
-	if row.JITCompiledMethods == nil || row.ClassesLoaded != nil {
+	row := sampleRow{
+		JITCompiledMethods: bigquery.NullInt64{Int64: 1, Valid: true},
+		ClassesLoaded:      bigquery.NullInt64{},
+	}
+	if !row.JITCompiledMethods.Valid || row.ClassesLoaded.Valid {
 		t.Fatal("sample row must preserve populated and null optional metrics")
 	}
 }


### PR DESCRIPTION
## Summary
- rebuild the fix branch from current main to avoid the stale PR conflict
- use BigQuery nullable integer values for optional JIT/class metric columns
- update exporter tests to preserve null vs populated metric values

## Why
Production BigQuery export failed with: field "jit_compiled_methods": type *int64 is not supported. Firestore had the new values, but BigQuery rejected the sample rows.

## Verification
- go test ./... from backend module