### PR TITLE
fix: overlay JIT and class compare traces

### DIFF
--- a/frontend/public/compare-shared.js
+++ b/frontend/public/compare-shared.js
@@ -1312,14 +1312,16 @@
                     ...layout.xaxis,
                     title: 'Elapsed (s)',
                     tickformat: null,
-                    type: 'linear',
-                    tickvals: isSplitMode ? tickVals : undefined,
-                    ticktext: isSplitMode ? tickText : undefined
+                    type: 'linear'
                 };
+                const labelTraces = (traces, label) => traces.map(trace => ({
+                    ...trace,
+                    name: `${label}: ${trace.name}`
+                }));
                 if (isSplitMode) {
                     const traces = [
-                        ...buildMetricTraces(baseData, timestamps, frameIndex, metric, baseStyle, elapsedSeconds),
-                        ...buildMetricTraces(compareData, timestamps, frameIndex, metric, compareStyle, compareElapsed)
+                        ...labelTraces(buildMetricTraces(baseData, timestamps, frameIndex, metric, baseStyle, elapsedSeconds), baseLabel),
+                        ...labelTraces(buildMetricTraces(compareData, timestamps, frameIndex, metric, compareStyle, elapsedSeconds), compareLabel)
                     ];
                     tasks.push(Plotly.react(`compare-${id}`, applyVisibilityToTraces(`compare-${id}`, traces), layout, getCounterConfig(`compare-${metric}`)));
                 } else {


### PR DESCRIPTION
## Summary

JIT and Class Loading compare charts now overlay the current and comparison runs on the same elapsed-time axis, so differences are visible directly instead of being hidden by the split-view offset.

The traces are also labeled with the run name to avoid duplicate process labels in the legend.

## Verification

- `node --check frontend/public/compare-shared.js`
- `npm test -- --runInBand`
