### PR TITLE
fix: align JIT and class counters in compare timelines

### DIFF
--- a/__tests__/compare-shared.test.ts
+++ b/__tests__/compare-shared.test.ts
@@ -31,6 +31,18 @@ describe('JIT and class loading series', () => {
     expect(Array.from(result.rate)).toEqual([null, null, null, 4]);
   });
 
+  it('aligns counter observations to the next shared compare frame', () => {
+    const timestamps = [0, 2000, 4000, 6000];
+    const samples = [
+      { Timestamp: 1500, Name: 'P', PID: '1', JITCompiledMethods: 10 },
+      { Timestamp: 3500, Name: 'P', PID: '1', JITCompiledMethods: 30 },
+      { Timestamp: 5500, Name: 'P', PID: '1', JITCompiledMethods: 50 },
+    ];
+    const result = shared.buildCounterSeries(samples, timestamps, 'P', '1', (s: any) => s.JITCompiledMethods);
+    expect(Array.from(result.cumulative)).toEqual([null, 10, 30, 50]);
+    expect(Array.from(result.rate)).toEqual([null, null, 10, 10]);
+  });
+
   it('breaks a rate segment when a counter decreases and isolates PIDs', () => {
     const samples = [
       { Timestamp: 0, Name: 'P', PID: '1', JITCompiledMethods: 10 },

--- a/frontend/public/compare-shared.js
+++ b/frontend/public/compare-shared.js
@@ -221,27 +221,48 @@
             .filter(point => isValidMetric(point.value))
             .map(point => ({ ...point, value: Number(point.value) }))
             .sort((a, b) => a.timestamp - b.timestamp);
-        const observationByTimestamp = new Map(observations.map(point => [point.timestamp, point.value]));
-        const rateByTimestamp = new Map();
+        const rateObservations = [];
         let previous = null;
         observations.forEach(point => {
             if (previous) {
                 const elapsedSeconds = (point.timestamp - previous.timestamp) / 1000;
                 if (elapsedSeconds > 0 && point.value >= previous.value) {
-                    rateByTimestamp.set(point.timestamp, (point.value - previous.value) / elapsedSeconds);
+                    rateObservations.push({
+                        timestamp: point.timestamp,
+                        value: (point.value - previous.value) / elapsedSeconds
+                    });
                 }
             }
             previous = point;
         });
 
         let displayValue = null;
+        let observationIndex = 0;
+        let rateIndex = 0;
+        let lastRate = null;
+        let lastRateTimestamp = 0;
+        const medianDelta = getMedianDelta(timestamps);
+        const maxGap = medianDelta ? medianDelta * 2 : 0;
         return {
             observations,
             cumulative: timestamps.map(timestamp => {
-                if (observationByTimestamp.has(timestamp)) displayValue = observationByTimestamp.get(timestamp);
+                while (observationIndex < observations.length && observations[observationIndex].timestamp <= timestamp) {
+                    displayValue = observations[observationIndex].value;
+                    observationIndex += 1;
+                }
                 return displayValue;
             }),
-            rate: timestamps.map(timestamp => rateByTimestamp.has(timestamp) ? rateByTimestamp.get(timestamp) : null)
+            rate: timestamps.map(timestamp => {
+                while (rateIndex < rateObservations.length && rateObservations[rateIndex].timestamp <= timestamp) {
+                    lastRate = rateObservations[rateIndex].value;
+                    lastRateTimestamp = rateObservations[rateIndex].timestamp;
+                    rateIndex += 1;
+                }
+                if (lastRateTimestamp === timestamp || (maxGap > 0 && lastRateTimestamp > 0 && (timestamp - lastRateTimestamp) <= maxGap)) {
+                    return lastRate;
+                }
+                return null;
+            })
         };
     }
 


### PR DESCRIPTION
## Summary

JIT and Class Loading compare charts now keep counter values visible even when the two uploaded runs sampled at different seconds. The counter series advances to the latest observation at or before each shared frame, matching the forward-filled behavior that already made GC compare correctly.

Before this, GC could show both runs while JIT/Class only showed one run because counter metrics required exact timestamp matches on the shared compare timeline.

## Verification

- `node --check frontend/public/compare-shared.js`
- `npm test -- --runInBand`
