### PR TITLE
fix: guard chart studio render target

### DIFF
--- a/frontend/public/chart-studio.js
+++ b/frontend/public/chart-studio.js
@@ -105,12 +105,24 @@
         `;
     }
 
+    function ensureStudioMounted(host) {
+        if (!host) return false;
+        if (document.getElementById('bpw-studio-chart')) return true;
+
+        host.innerHTML = buildStudioMarkup(getAvailableMetrics());
+        bindStudioControls();
+        state.bound = true;
+        return Boolean(document.getElementById('bpw-studio-chart'));
+    }
+
     function renderStudio() {
         const host = document.getElementById('bpw-chart-studio');
         if (!host || host.hidden) return Promise.resolve();
+        if (!ensureStudioMounted(host)) return Promise.resolve();
 
         const shared = getShared();
         if (!shared.buildOverlayTraces || !state.replayData) return Promise.resolve();
+        if (typeof Plotly === 'undefined') return Promise.resolve();
 
         const xValues = state.useElapsedAxis ? state.elapsedSeconds : null;
         const traces = shared.applyVisibilityToTraces(
@@ -240,12 +252,10 @@
         const host = document.getElementById('bpw-chart-studio');
         if (!host) return;
 
-        const available = getAvailableMetrics();
         if (!state.bound) {
-            host.innerHTML = buildStudioMarkup(available);
-            bindStudioControls();
-            state.bound = true;
+            ensureStudioMounted(host);
         } else {
+            ensureStudioMounted(host);
             const selectA = document.getElementById('bpw-studio-layer-a');
             const selectB = document.getElementById('bpw-studio-layer-b');
             if (selectA) selectA.value = state.metricA;


### PR DESCRIPTION
## Summary

Chart Studio no longer crashes run loading when the studio host exists but its Plotly chart node has not been mounted yet. Navigation between classic/studio/story modes now remounts the studio shell before calling Plotly, and rendering safely no-ops if Plotly or the chart target is unavailable.

Fixes cdsap/build-process-watcher#57.

## Validation

- `node --check frontend/public/chart-studio.js`
- `npm test -- --runInBand`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
