### PR TITLE
fix: tolerate Firebase active-version deploy retry

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -41,14 +41,36 @@ jobs:
         echo "  frontendUrl: '${FE_URL}'" >> frontend/public/config.js
         echo "};" >> frontend/public/config.js
 
+    - name: Configure Firebase credentials
+      env:
+        FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+      run: |
+        credentials_file="${RUNNER_TEMP}/firebase-service-account.json"
+        printf '%s' "${FIREBASE_SERVICE_ACCOUNT}" > "${credentials_file}"
+        echo "GOOGLE_APPLICATION_CREDENTIALS=${credentials_file}" >> "${GITHUB_ENV}"
+
     - name: Deploy to Firebase Hosting
-      uses: FirebaseExtended/action-hosting-deploy@v0
-      with:
-        repoToken: ${{ secrets.GITHUB_TOKEN }}
-        firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-        projectId: ${{ secrets.FIREBASE_PROJECT_ID }}
-        entryPoint: ./frontend
-        channelId: live
+      working-directory: ./frontend
+      env:
+        FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+      run: |
+        set +e
+        deploy_output="$(npx firebase-tools@latest deploy --only hosting --project "${FIREBASE_PROJECT_ID}" --json 2>&1)"
+        deploy_status=$?
+        set -e
+
+        printf '%s\n' "${deploy_output}"
+
+        if [ "${deploy_status}" -eq 0 ]; then
+          exit 0
+        fi
+
+        if printf '%s\n' "${deploy_output}" | grep -q "is the current active version"; then
+          echo "Firebase Hosting already released this version; treating the idempotent retry as successful."
+          exit 0
+        fi
+
+        exit "${deploy_status}"
 
 
     - name: Output deployment URL


### PR DESCRIPTION
## Summary
- replace the Firebase Hosting action with a direct Firebase CLI deploy wrapper
- configure Firebase service-account credentials through GOOGLE_APPLICATION_CREDENTIALS
- treat Firebase's idempotent 'current active version' retry response as success while still failing other deploy errors

## Context
The main deploy job failed because Firebase completed/released the Hosting version, then a retry attempted to release the same now-active version and returned HTTP 400: 'supplied version ... is the current active version'.

Failed run: https://github.com/cdsap/build-process-watcher/actions/runs/28274579353/job/83778644957

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy-frontend.yml'); puts 'yaml ok'"
- git diff --check