### PR TITLE
fix: add accessible names to replay timeline and speed controls

### DIFF
--- a/__tests__/replay-accessibility.test.ts
+++ b/__tests__/replay-accessibility.test.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('completed-run replay controls', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '../frontend/public/runs/[runId].html'),
+    'utf8'
+  );
+
+  test.each([
+    ['rss', 'Memory'],
+    ['gc', 'GC'],
+    ['ratio', 'Heap/RSS ratio'],
+    ['jit', 'JIT'],
+    ['classes', 'Class loading'],
+  ])('gives the %s timeline and speed controls unique accessible names', (panel, name) => {
+    expect(source).toContain(
+      `<input type="range" id="${panel}-replay-timeline" aria-label="${name} replay timeline"`
+    );
+    expect(source).toContain(
+      `<select id="${panel}-replay-speed" aria-label="${name} replay speed">`
+    );
+  });
+});

--- a/frontend/public/runs/[runId].html
+++ b/frontend/public/runs/[runId].html
@@ -876,11 +876,11 @@
                             </div>
                             <div class="meta" id="rss-replay-meta">Frame 0 / 0</div>
                             <div class="timeline">
-                                <input type="range" id="rss-replay-timeline" min="0" max="0" value="0">
+                                <input type="range" id="rss-replay-timeline" aria-label="Memory replay timeline" min="0" max="0" value="0">
                                 <div class="meta" id="rss-replay-time-label">Elapsed: 0s</div>
                                 <div class="meta">
                                     Speed:
-                                    <select id="rss-replay-speed">
+                                    <select id="rss-replay-speed" aria-label="Memory replay speed">
                                         <option value="5">5x</option>
                                         <option value="10">10x</option>
                                         <option value="15" selected>15x</option>
@@ -934,11 +934,11 @@
                             </div>
                             <div class="meta" id="gc-replay-meta">Frame 0 / 0</div>
                             <div class="timeline">
-                                <input type="range" id="gc-replay-timeline" min="0" max="0" value="0">
+                                <input type="range" id="gc-replay-timeline" aria-label="GC replay timeline" min="0" max="0" value="0">
                                 <div class="meta" id="gc-replay-time-label">Elapsed: 0s</div>
                                 <div class="meta">
                                     Speed:
-                                    <select id="gc-replay-speed">
+                                    <select id="gc-replay-speed" aria-label="GC replay speed">
                                         <option value="5">5x</option>
                                         <option value="10">10x</option>
                                         <option value="15" selected>15x</option>
@@ -987,11 +987,11 @@
                             </div>
                             <div class="meta" id="ratio-replay-meta">Frame 0 / 0</div>
                             <div class="timeline">
-                                <input type="range" id="ratio-replay-timeline" min="0" max="0" value="0">
+                                <input type="range" id="ratio-replay-timeline" aria-label="Heap/RSS ratio replay timeline" min="0" max="0" value="0">
                                 <div class="meta" id="ratio-replay-time-label">Elapsed: 0s</div>
                                 <div class="meta">
                                     Speed:
-                                    <select id="ratio-replay-speed">
+                                    <select id="ratio-replay-speed" aria-label="Heap/RSS ratio replay speed">
                                         <option value="5">5x</option>
                                         <option value="10">10x</option>
                                         <option value="15" selected>15x</option>
@@ -1036,11 +1036,11 @@
                             </div>
                             <div class="meta" id="jit-replay-meta">Frame 0 / 0</div>
                             <div class="timeline">
-                                <input type="range" id="jit-replay-timeline" min="0" max="0" value="0">
+                                <input type="range" id="jit-replay-timeline" aria-label="JIT replay timeline" min="0" max="0" value="0">
                                 <div class="meta" id="jit-replay-time-label">Elapsed: 0s</div>
                                 <div class="meta">
                                     Speed:
-                                    <select id="jit-replay-speed">
+                                    <select id="jit-replay-speed" aria-label="JIT replay speed">
                                         <option value="5">5x</option>
                                         <option value="10">10x</option>
                                         <option value="15" selected>15x</option>
@@ -1090,11 +1090,11 @@
                             </div>
                             <div class="meta" id="classes-replay-meta">Frame 0 / 0</div>
                             <div class="timeline">
-                                <input type="range" id="classes-replay-timeline" min="0" max="0" value="0">
+                                <input type="range" id="classes-replay-timeline" aria-label="Class loading replay timeline" min="0" max="0" value="0">
                                 <div class="meta" id="classes-replay-time-label">Elapsed: 0s</div>
                                 <div class="meta">
                                     Speed:
-                                    <select id="classes-replay-speed">
+                                    <select id="classes-replay-speed" aria-label="Class loading replay speed">
                                         <option value="5">5x</option>
                                         <option value="10">10x</option>
                                         <option value="15" selected>15x</option>


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/build-process-watcher#61: Add accessible names to replay timeline and speed controls

Fixes #61

## Verification

- `npm test -- --runInBand`