### PR TITLE
fix: all application routes emit uncaught syntaxerror: unexpected token

### DIFF
--- a/__tests__/frontend-assets.test.ts
+++ b/__tests__/frontend-assets.test.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const publicDir = path.join(__dirname, '../frontend/public');
+
+function htmlFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return htmlFiles(entryPath);
+    return entry.name.endsWith('.html') ? [entryPath] : [];
+  });
+}
+
+describe('frontend script assets', () => {
+  it('includes every local script referenced by an HTML page', () => {
+    const missing: string[] = [];
+
+    for (const htmlFile of htmlFiles(publicDir)) {
+      const html = fs.readFileSync(htmlFile, 'utf8');
+      for (const match of html.matchAll(/<script\s[^>]*src=["']([^"']+)["']/g)) {
+        const source = match[1];
+        if (/^https?:\/\//.test(source)) continue;
+
+        const assetPath = source.startsWith('/')
+          ? path.join(publicDir, source.slice(1))
+          : path.resolve(path.dirname(htmlFile), source);
+        if (!fs.existsSync(assetPath)) {
+          missing.push(`${path.relative(publicDir, htmlFile)}: ${source}`);
+        }
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -1,0 +1,8 @@
+(function () {
+    'use strict';
+
+    window.BUILD_PROCESS_WATCHER_CONFIG = window.BUILD_PROCESS_WATCHER_CONFIG || {
+        frontendUrl: 'https://process-watcher.web.app',
+        backendUrl: 'https://build-process-watcher-backend-685615422311.us-central1.run.app'
+    };
+})();


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/build-process-watcher#60: All application routes emit uncaught SyntaxError: Unexpected token '<'

Fixes #60

## Verification

- `npm test -- --runInBand`