### PR TITLE
fix: serve valid robots.txt and sitemap.xml instead of homepage html

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -77,3 +77,40 @@ jobs:
       run: |
         echo "🌐 Frontend deployed successfully!"
         echo "🔗 Frontend URL: ${FRONTEND_URL}"
+
+    - name: Verify crawler endpoints
+      run: |
+        set -euo pipefail
+
+        verify_endpoint() {
+          path="$1"
+          expected_type="$2"
+          expected_content="$3"
+          headers_file="$(mktemp)"
+          body_file="$(mktemp)"
+          trap 'rm -f "${headers_file}" "${body_file}"' RETURN
+
+          curl --fail --silent --show-error \
+            --dump-header "${headers_file}" \
+            --output "${body_file}" \
+            "https://process-watcher.web.app${path}"
+
+          content_type="$(grep -i '^content-type:' "${headers_file}" | tail -n 1 | tr -d '\r')"
+          case "${content_type}" in
+            *"${expected_type}"*) ;;
+            *)
+              echo "Unexpected Content-Type for ${path}: ${content_type}"
+              exit 1
+              ;;
+          esac
+
+          if ! grep -Fq "${expected_content}" "${body_file}"; then
+            echo "Expected content was not found at ${path}"
+            exit 1
+          fi
+        }
+
+        verify_endpoint "/robots.txt" "text/plain" \
+          "Sitemap: https://process-watcher.web.app/sitemap.xml"
+        verify_endpoint "/sitemap.xml" "application/xml" \
+          "<loc>https://process-watcher.web.app/</loc>"

--- a/__tests__/crawler-resources.test.ts
+++ b/__tests__/crawler-resources.test.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repositoryRoot = path.resolve(__dirname, '..');
+const publicDirectory = path.join(repositoryRoot, 'frontend', 'public');
+
+describe('crawler resources', () => {
+  it('serves crawler directives that reference the production sitemap', () => {
+    const robots = fs.readFileSync(path.join(publicDirectory, 'robots.txt'), 'utf8');
+
+    expect(robots).toContain('User-agent: *');
+    expect(robots).toContain('Disallow: /runs/');
+    expect(robots).toContain('Disallow: /replay.html');
+    expect(robots).toContain('Disallow: /compare.html');
+    expect(robots).toContain('Sitemap: https://process-watcher.web.app/sitemap.xml');
+  });
+
+  it('lists only the canonical public homepage in the sitemap', () => {
+    const sitemap = fs.readFileSync(path.join(publicDirectory, 'sitemap.xml'), 'utf8');
+    const locations = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(match => match[1]);
+
+    expect(sitemap).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+    expect(sitemap).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(locations).toEqual(['https://process-watcher.web.app/']);
+  });
+
+  it('configures explicit content types for both crawler resources', () => {
+    const firebaseConfig = JSON.parse(
+      fs.readFileSync(path.join(repositoryRoot, 'frontend', 'firebase.json'), 'utf8')
+    );
+    const headers = firebaseConfig.hosting.headers;
+
+    expect(headers).toEqual(
+      expect.arrayContaining([
+        {
+          source: '/robots.txt',
+          headers: [{ key: 'Content-Type', value: 'text/plain; charset=utf-8' }],
+        },
+        {
+          source: '/sitemap.xml',
+          headers: [{ key: 'Content-Type', value: 'application/xml; charset=utf-8' }],
+        },
+      ])
+    );
+  });
+});

--- a/frontend/firebase.json
+++ b/frontend/firebase.json
@@ -19,6 +19,18 @@
     ],
     "headers": [
       {
+        "source": "/robots.txt",
+        "headers": [
+          { "key": "Content-Type", "value": "text/plain; charset=utf-8" }
+        ]
+      },
+      {
+        "source": "/sitemap.xml",
+        "headers": [
+          { "key": "Content-Type", "value": "application/xml; charset=utf-8" }
+        ]
+      },
+      {
         "source": "/runs/**",
         "headers": [
           { "key": "Cache-Control", "value": "no-cache" }

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Disallow: /runs/
+Disallow: /replay.html
+Disallow: /compare.html
+
+Sitemap: https://process-watcher.web.app/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://process-watcher.web.app/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/build-process-watcher#75: Serve valid robots.txt and sitemap.xml instead of homepage HTML

Fixes #75

## Verification

- `npm test -- --runInBand`