### PR TITLE
fix: add essential seo and social metadata to public pages

### DIFF
--- a/__tests__/frontend-metadata.test.ts
+++ b/__tests__/frontend-metadata.test.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const publicDir = path.join(__dirname, '../frontend/public');
+
+const publicPages = [
+  { file: 'index.html', canonical: 'https://process-watcher.web.app/' },
+  { file: 'compare.html', canonical: 'https://process-watcher.web.app/compare.html', noindex: true },
+  { file: 'replay.html', canonical: 'https://process-watcher.web.app/replay.html', noindex: true },
+  { file: 'runs/demo.html', canonical: 'https://process-watcher.web.app/runs/demo.html' },
+];
+
+function readPage(file: string): string {
+  return fs.readFileSync(path.join(publicDir, file), 'utf8');
+}
+
+function metaContent(html: string, attribute: 'name' | 'property', value: string): string | undefined {
+  const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return html.match(new RegExp(`<meta\\s+${attribute}=["']${escaped}["']\\s+content=["']([^"']+)["']`, 'i'))?.[1];
+}
+
+describe('frontend discovery and social metadata', () => {
+  it.each(publicPages)('$file has complete page-specific sharing metadata', ({ file, canonical, noindex }) => {
+    const html = readPage(file);
+    const description = metaContent(html, 'name', 'description');
+    const canonicalUrl = html.match(/<link\s+rel=["']canonical["']\s+href=["']([^"']+)["']/i)?.[1];
+
+    expect(description).toBeTruthy();
+    expect(canonicalUrl).toBe(canonical);
+    expect(metaContent(html, 'property', 'og:title')).toBeTruthy();
+    expect(metaContent(html, 'property', 'og:description')).toBe(description);
+    expect(metaContent(html, 'property', 'og:url')).toBe(canonical);
+    expect(metaContent(html, 'property', 'og:type')).toBe('website');
+    expect(metaContent(html, 'name', 'twitter:card')).toBe('summary_large_image');
+    expect(metaContent(html, 'name', 'twitter:title')).toBeTruthy();
+    expect(metaContent(html, 'name', 'twitter:description')).toBe(description);
+
+    const openGraphImage = metaContent(html, 'property', 'og:image');
+    for (const url of [canonicalUrl, metaContent(html, 'property', 'og:url'), openGraphImage, metaContent(html, 'name', 'twitter:image')]) {
+      expect(url).toMatch(/^https:\/\//);
+    }
+    expect(fs.existsSync(path.join(publicDir, new URL(openGraphImage!).pathname))).toBe(true);
+
+    if (noindex) expect(metaContent(html, 'name', 'robots')).toMatch(/\bnoindex\b/);
+  });
+
+  it('uses unique descriptions and titles for public pages', () => {
+    const pages = publicPages.map(({ file }) => readPage(file));
+    const descriptions = pages.map(html => metaContent(html, 'name', 'description'));
+    const titles = pages.map(html => metaContent(html, 'property', 'og:title'));
+
+    expect(new Set(descriptions).size).toBe(publicPages.length);
+    expect(new Set(titles).size).toBe(publicPages.length);
+  });
+
+  it.each(['runs/[runId].html', 'runs/index.html'])('%s prevents indexing of ephemeral run routes', file => {
+    expect(metaContent(readPage(file), 'name', 'robots')).toMatch(/\bnoindex\b/);
+  });
+});

--- a/frontend/public/compare.html
+++ b/frontend/public/compare.html
@@ -4,6 +4,18 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Build Process Watcher - Compare JSON Runs</title>
+    <meta name="description" content="Compare two Build Process Watcher JSON reports to examine Gradle and Kotlin build performance differences.">
+    <meta name="robots" content="noindex, follow">
+    <link rel="canonical" href="https://process-watcher.web.app/compare.html">
+    <meta property="og:title" content="Build Process Watcher - Compare JSON Runs">
+    <meta property="og:description" content="Compare two Build Process Watcher JSON reports to examine Gradle and Kotlin build performance differences.">
+    <meta property="og:url" content="https://process-watcher.web.app/compare.html">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://process-watcher.web.app/gha_log.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Build Process Watcher - Compare JSON Runs">
+    <meta name="twitter:description" content="Compare two Build Process Watcher JSON reports to examine Gradle and Kotlin build performance differences.">
+    <meta name="twitter:image" content="https://process-watcher.web.app/gha_log.png">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
     <script src="/config.js"></script>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,6 +4,18 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Build Process Watcher - Monitor Gradle Build Performance</title>
+    <meta name="description" content="Monitor Gradle and Kotlin build process memory, CPU, garbage collection, and performance over time.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://process-watcher.web.app/">
+    <meta property="og:title" content="Build Process Watcher - Monitor Gradle Build Performance">
+    <meta property="og:description" content="Monitor Gradle and Kotlin build process memory, CPU, garbage collection, and performance over time.">
+    <meta property="og:url" content="https://process-watcher.web.app/">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://process-watcher.web.app/gha_log.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Build Process Watcher - Monitor Gradle Build Performance">
+    <meta name="twitter:description" content="Monitor Gradle and Kotlin build process memory, CPU, garbage collection, and performance over time.">
+    <meta name="twitter:image" content="https://process-watcher.web.app/gha_log.png">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="stylesheet" href="/bpw-ui.css">
     <style>

--- a/frontend/public/replay.html
+++ b/frontend/public/replay.html
@@ -4,6 +4,18 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Build Process Watcher - Replay JSON</title>
+    <meta name="description" content="Replay a Build Process Watcher JSON report locally to inspect Gradle and Kotlin build process metrics.">
+    <meta name="robots" content="noindex, follow">
+    <link rel="canonical" href="https://process-watcher.web.app/replay.html">
+    <meta property="og:title" content="Build Process Watcher - Replay JSON Reports">
+    <meta property="og:description" content="Replay a Build Process Watcher JSON report locally to inspect Gradle and Kotlin build process metrics.">
+    <meta property="og:url" content="https://process-watcher.web.app/replay.html">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://process-watcher.web.app/gha_log.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Build Process Watcher - Replay JSON Reports">
+    <meta name="twitter:description" content="Replay a Build Process Watcher JSON report locally to inspect Gradle and Kotlin build process metrics.">
+    <meta name="twitter:image" content="https://process-watcher.web.app/gha_log.png">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
     <script src="/config.js"></script>

--- a/frontend/public/runs/[runId].html
+++ b/frontend/public/runs/[runId].html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Build Process Watcher - Run Dashboard</title>
+    <meta name="robots" content="noindex, follow">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
     <script src="/config.js"></script>

--- a/frontend/public/runs/demo.html
+++ b/frontend/public/runs/demo.html
@@ -7,6 +7,18 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Build Process Watcher - Example Dashboard</title>
+    <meta name="description" content="Explore an example Build Process Watcher dashboard with Gradle daemon memory and performance metrics.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://process-watcher.web.app/runs/demo.html">
+    <meta property="og:title" content="Build Process Watcher - Example Dashboard">
+    <meta property="og:description" content="Explore an example Build Process Watcher dashboard with Gradle daemon memory and performance metrics.">
+    <meta property="og:url" content="https://process-watcher.web.app/runs/demo.html">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://process-watcher.web.app/gha_log.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Build Process Watcher - Example Dashboard">
+    <meta name="twitter:description" content="Explore an example Build Process Watcher dashboard with Gradle daemon memory and performance metrics.">
+    <meta name="twitter:image" content="https://process-watcher.web.app/gha_log.png">
     <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
     <script src="/config.js"></script>
     <style>

--- a/frontend/public/runs/index.html
+++ b/frontend/public/runs/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Run Not Found - Build Process Watcher</title>
+    <meta name="robots" content="noindex, nofollow">
     <style>
         * {
             box-sizing: border-box;


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/build-process-watcher#74: Add essential SEO and social metadata to public pages

Fixes #74

## Verification

- `npm test -- --runInBand`