### PR TITLE
fix: add accessible labels to replay and compare playback controls

### DIFF
--- a/__tests__/replay-accessibility.test.ts
+++ b/__tests__/replay-accessibility.test.ts
@@ -22,3 +22,20 @@ describe('completed-run replay controls', () => {
     );
   });
 });
+
+describe('production replay controls', () => {
+  test.each([
+    ['Replay', '../frontend/public/replay.js', 'single-replay'],
+    ['Replay unified view', '../frontend/public/replay.js', 'bpw-unified'],
+    ['Compare', '../frontend/public/compare-shared.js', 'compare-replay'],
+  ])('%s exposes a named slider and combobox', (_page, relativePath, controlPrefix) => {
+    const source = fs.readFileSync(path.join(__dirname, relativePath), 'utf8');
+
+    expect(source).toContain(
+      `type="range" id="${controlPrefix}-timeline" aria-label="Replay position"`
+    );
+    expect(source).toContain(
+      `id="${controlPrefix}-speed" aria-label="Playback speed"`
+    );
+  });
+});

--- a/frontend/public/compare-shared.js
+++ b/frontend/public/compare-shared.js
@@ -1233,11 +1233,11 @@
                 </div>
                 <div class="meta" id="compare-replay-meta">Frame 0 / 0</div>
                 <div class="timeline">
-                    <input type="range" id="compare-replay-timeline" min="0" max="0" value="0">
+                    <input type="range" id="compare-replay-timeline" aria-label="Replay position" min="0" max="0" value="0">
                     <div class="meta" id="compare-replay-time-label">Elapsed: 0s</div>
                     <div class="meta">
                         Speed:
-                        <select id="compare-replay-speed">
+                        <select id="compare-replay-speed" aria-label="Playback speed">
                             <option value="5">5x</option>
                             <option value="10">10x</option>
                             <option value="15" selected>15x</option>

--- a/frontend/public/replay.js
+++ b/frontend/public/replay.js
@@ -53,11 +53,11 @@
                     </div>
                     <div class="meta" id="bpw-unified-meta">Frame 0 / 0</div>
                     <div class="timeline">
-                        <input type="range" id="bpw-unified-timeline" min="0" max="0" value="0">
+                        <input type="range" id="bpw-unified-timeline" aria-label="Replay position" min="0" max="0" value="0">
                         <div class="meta" id="bpw-unified-time-label">Elapsed: 0s</div>
                         <div class="meta">
                             Speed:
-                            <select id="bpw-unified-speed">
+                            <select id="bpw-unified-speed" aria-label="Playback speed">
                                 <option value="15" selected>15x</option>
                                 <option value="25">25x</option>
                                 <option value="50">50x</option>
@@ -77,11 +77,11 @@
                 </div>
                 <div class="meta" id="single-replay-meta">Frame 0 / 0</div>
                 <div class="timeline">
-                    <input type="range" id="single-replay-timeline" min="0" max="0" value="0">
+                    <input type="range" id="single-replay-timeline" aria-label="Replay position" min="0" max="0" value="0">
                     <div class="meta" id="single-replay-time-label">Elapsed: 0s</div>
                     <div class="meta">
                         Speed:
-                        <select id="single-replay-speed">
+                        <select id="single-replay-speed" aria-label="Playback speed">
                             <option value="5">5x</option>
                             <option value="10">10x</option>
                             <option value="15" selected>15x</option>


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/build-process-watcher#73: Add accessible labels to replay and compare playback controls

Fixes #73

## Verification

- `npm test -- --runInBand`