### PR TITLE
fix: show an actionable unavailable-run state instead of raw “failed to

### DIFF
--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -28,6 +28,14 @@ jobs:
       with:
         node-version: '20'
 
+    - name: Install browser test dependencies
+      run: |
+        npm ci
+        npx playwright install --with-deps chromium
+
+    - name: Test unavailable run states
+      run: npm run test:browser
+
     - name: Install HTML validation tools
       run: |
         echo "📦 Installing validation tools..."
@@ -151,4 +159,3 @@ jobs:
         echo "  - Config injection tested"
         echo "  - JavaScript syntax checked"
         echo "  - Static assets verified"
-

--- a/__tests__/run-dashboard-unavailable.test.ts
+++ b/__tests__/run-dashboard-unavailable.test.ts
@@ -1,0 +1,22 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('run dashboard unavailable state', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '../frontend/public/runs/[runId].html'),
+    'utf8',
+  );
+
+  it('classifies unavailable responses without rendering low-level fetch errors', () => {
+    expect(source).toContain("response.status === 404 || response.status === 410");
+    expect(source).toContain("showUnavailableRun('server')");
+    expect(source).toContain("showUnavailableRun(response ? 'server' : 'connectivity')");
+    expect(source).not.toContain('Failed to load run data: ${message}');
+  });
+
+  it('offers retry and home actions', () => {
+    expect(source).toContain('id="retry-run-load"');
+    expect(source).toContain("addEventListener('click', () => loadRunData(runId))");
+    expect(source).toContain('Back to Home');
+  });
+});

--- a/frontend/public/runs/[runId].html
+++ b/frontend/public/runs/[runId].html
@@ -521,15 +521,21 @@
 
         async function loadRunData(runId) {
             const backendUrl = window.BUILD_PROCESS_WATCHER_CONFIG?.backendUrl || 'https://build-process-watcher-backend-685615422311.us-central1.run.app';
+            let response;
             
             try {
-                const response = await fetch(`${backendUrl}/runs/${runId}`);
+                response = await fetch(`${backendUrl}/runs/${runId}`);
                 
                 if (!response.ok) {
-                    if (response.status === 404) {
-                        showNotFound(runId);
+                    console.error('Run data request failed:', {
+                        runId,
+                        status: response.status,
+                        statusText: response.statusText
+                    });
+                    if (response.status === 404 || response.status === 410) {
+                        showUnavailableRun('not-found');
                     } else {
-                        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                        showUnavailableRun('server');
                     }
                     return;
                 }
@@ -546,8 +552,8 @@
                 }
                 
             } catch (error) {
-                console.error('Error loading run data:', error);
-                showError(error.message);
+                console.error('Run data request could not be completed:', { runId, error });
+                showUnavailableRun(response ? 'server' : 'connectivity');
             }
         }
 
@@ -2639,30 +2645,33 @@
             return CompareShared.getMemoryConfig(`build-monitor-${runId}`);
         }
 
-        function showNotFound(runId) {
-            document.getElementById('content').innerHTML = `
-                <div class="not-found">
-                    <h2>Run Not Found</h2>
-                    <p>The build run with ID <code>${runId}</code> could not be found.</p>
-                    <p>This might be because:</p>
-                    <ul style="text-align: left; max-width: 400px; margin: 0 auto;">
-                        <li>The memory report has expired (available for 24 hours)</li>
-                        <li>The run ID is incorrect</li>
-                        <li>The build is still in progress</li>
-                    </ul>
-                    <a href="https://process-watcher.web.app" style="color: #2563eb; text-decoration: none;">Back to Home</a>
-                </div>
-            `;
-        }
+        function showUnavailableRun(reason) {
+            const unavailableCopy = reason === 'not-found'
+                ? {
+                    title: 'Run Unavailable',
+                    message: 'This run could not be found. The link may be incorrect, or the run may have expired.'
+                }
+                : reason === 'server'
+                    ? {
+                        title: 'Run Temporarily Unavailable',
+                        message: 'The service could not load this run right now. Please try again.'
+                    }
+                    : {
+                        title: 'Unable to Connect',
+                        message: 'Check your connection, then try loading this run again.'
+                    };
 
-        function showError(message) {
             document.getElementById('content').innerHTML = `
                 <div class="error">
-                    <h2>Error Loading Data</h2>
-                    <p>Failed to load run data: ${message}</p>
-                    <a href="https://process-watcher.web.app" style="color: #2563eb; text-decoration: none;">Back to Home</a>
+                    <h2>${unavailableCopy.title}</h2>
+                    <p>${unavailableCopy.message}</p>
+                    <div style="display: flex; justify-content: center; gap: 1rem; flex-wrap: wrap;">
+                        <button type="button" id="retry-run-load">Retry</button>
+                        <a href="https://process-watcher.web.app" style="color: #2563eb; text-decoration: none; align-self: center;">Back to Home</a>
+                    </div>
                 </div>
             `;
+            document.getElementById('retry-run-load').addEventListener('click', () => loadRunData(runId));
         }
     </script>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "firebase-admin": "^13.5.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.24",
         "@vercel/ncc": "^0.38.3",
@@ -1791,6 +1792,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobuf-ts/plugin": {
@@ -5778,6 +5795,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "./build.sh",
     "test": "jest",
-    "test:ci": "jest --ci --coverage"
+    "test:ci": "jest --ci --coverage",
+    "test:browser": "playwright test"
   },
   "keywords": [],
   "author": "",
@@ -18,6 +19,7 @@
     "firebase-admin": "^13.5.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.24",
     "jest": "^29.7.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,5 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests/browser',
+});

--- a/tests/browser/unavailable-run.spec.js
+++ b/tests/browser/unavailable-run.spec.js
@@ -1,0 +1,65 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const runPage = fs.readFileSync(
+  path.join(__dirname, '../../frontend/public/runs/[runId].html'),
+  'utf8',
+);
+
+async function serveRunPage(page) {
+  await page.route('https://cdn.plot.ly/**', route => route.fulfill({
+    contentType: 'text/javascript',
+    body: '',
+  }));
+  await page.route('https://frontend.test/**', route => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname.startsWith('/runs/')) {
+      return route.fulfill({ contentType: 'text/html', body: runPage });
+    }
+    return route.fulfill({ contentType: 'text/javascript', body: '' });
+  });
+}
+
+test('shows actions and user-oriented copy for a missing run', async ({ page }) => {
+  await serveRunPage(page);
+  await page.route('https://build-process-watcher-backend-685615422311.us-central1.run.app/runs/frontend-qa-missing-run', route => route.fulfill({ status: 404 }));
+
+  await page.goto('https://frontend.test/runs/frontend-qa-missing-run');
+
+  await expect(page.getByRole('heading', { name: 'Run Unavailable' })).toBeVisible();
+  await expect(page.getByText(/link may be incorrect, or the run may have expired/i)).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Back to Home' })).toBeVisible();
+  await expect(page.locator('#content')).not.toContainText('Failed to fetch');
+});
+
+test('distinguishes a server failure from a missing run', async ({ page }) => {
+  await serveRunPage(page);
+  await page.route('https://build-process-watcher-backend-685615422311.us-central1.run.app/runs/frontend-qa-server-error', route => route.fulfill({ status: 503 }));
+
+  await page.goto('https://frontend.test/runs/frontend-qa-server-error');
+
+  await expect(page.getByRole('heading', { name: 'Run Temporarily Unavailable' })).toBeVisible();
+  await expect(page.getByText(/service could not load this run right now/i)).toBeVisible();
+});
+
+test('distinguishes a connectivity failure and retries the request', async ({ page }) => {
+  await serveRunPage(page);
+  let attempts = 0;
+  await page.route('https://build-process-watcher-backend-685615422311.us-central1.run.app/runs/frontend-qa-offline-run', async route => {
+    attempts += 1;
+    if (attempts === 1) {
+      await route.abort('failed');
+    } else {
+      await route.fulfill({ status: 404 });
+    }
+  });
+
+  await page.goto('https://frontend.test/runs/frontend-qa-offline-run');
+
+  await expect(page.getByRole('heading', { name: 'Unable to Connect' })).toBeVisible();
+  await page.getByRole('button', { name: 'Retry' }).click();
+  await expect(page.getByRole('heading', { name: 'Run Unavailable' })).toBeVisible();
+  expect(attempts).toBe(2);
+});


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/build-process-watcher#72: Show an actionable unavailable-run state instead of raw “Failed to fetch”

Fixes #72

## Verification

- `npm test -- --runInBand`