### PR TITLE
fix: run GitHub Action on Node 24

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -48,6 +48,6 @@ branding:
   color: "gray-dark"
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index_with_backend.js'
   post: 'dist/cleanup.js'


### PR DESCRIPTION
## Summary

Build Process Watcher now declares the Node 24 GitHub Actions runtime, removing the Node 20 deprecation warning and aligning execution with the runtime GitHub already applies by default.

## Validation

- `npm test -- --runInBand` — 10 suites and 45 tests passed.
- `npm run build` — both bundled action entry points built successfully.
- `git diff --check` passed.

## Post-Deploy Monitoring & Validation

- Run the offline-mode experiment workflow that consumes `cdsap/build-process-watcher@main` after merge.
- Healthy signal: the action starts and completes without the Node 20 deprecation annotation.
- Failure signals: runtime initialization errors or failures in the action post-step.
- Mitigation: revert this one-line runtime declaration if Node 24 exposes an incompatible dependency.
- Validation window and owner: the first workflow run after merge, owned by the PR author.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
