### PR TITLE
fix: restore Mermaid summary palette

### DIFF
--- a/__tests__/mermaid.test.ts
+++ b/__tests__/mermaid.test.ts
@@ -17,17 +17,17 @@ function processData(overrides: Partial<MermaidProcessData> = {}): MermaidProces
 }
 
 describe('generateCombinedMermaidChart', () => {
-  it('uses a neutral theme and explicit high-contrast node colors', () => {
+  it('uses the original dark palette without an outer graph title', () => {
     const chart = generateCombinedMermaidChart(
       new Map([['123-GradleDaemon', processData()]]),
       ['00:00:00', '00:00:05'],
     );
 
-    expect(chart).toContain("'theme': 'base'");
-    expect(chart).toContain("'primaryTextColor': '#0F172A'");
-    expect(chart).toContain('classDef process fill:#D8F3F0,stroke:#0F766E,color:#0F172A');
-    expect(chart).toContain('classDef aggregated fill:#FEE2E2,stroke:#B91C1C,color:#0F172A');
-    expect(chart).not.toContain("'theme': 'dark'");
+    expect(chart).toContain("'theme': 'dark'");
+    expect(chart).toContain('subgraph Time[" "]');
+    expect(chart).not.toContain('JVM Telemetry Over Time');
+    expect(chart).toContain('classDef process fill:#4ECDC4,stroke:#333,stroke-width:2px');
+    expect(chart).toContain('classDef aggregated fill:#FF6B6B,stroke:#333,stroke-width:2px');
   });
 
   it('shows all available JVM metrics in each process node', () => {

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -215293,9 +215293,9 @@ function generateCombinedMermaidChart(processes, timestamps) {
         const cleanKey = key.replace(/[^a-zA-Z0-9]/g, '_');
         return sampledTimestamps.flatMap((timestamp, index) => data.timestamps.includes(timestamp) ? [`${cleanKey}_${index}`] : []);
     });
-    return `%%{init: {'theme': 'base', 'themeVariables': {'primaryTextColor': '#0F172A', 'lineColor': '#475569', 'clusterBkg': '#F8FAFC', 'clusterBorder': '#94A3B8', 'titleColor': '#0F172A'}}}%%
+    return `%%{init: {'theme': 'dark'}}%%
 flowchart LR
-    subgraph Time["JVM Telemetry Over Time"]
+    subgraph Time[" "]
         direction TB
         ${sampledTimestamps.map((timestamp, checkpointIndex) => {
         const processNodes = Array.from(processes.entries()).map(([key, data]) => {
@@ -215331,8 +215331,8 @@ flowchart LR
         ? ''
         : `    Agg_${checkpointIndex - 1} --> Agg_${checkpointIndex}`).filter(Boolean).join('\n    ')}
 
-    classDef process fill:#D8F3F0,stroke:#0F766E,color:#0F172A,stroke-width:2px
-    classDef aggregated fill:#FEE2E2,stroke:#B91C1C,color:#0F172A,stroke-width:2px
+    classDef process fill:#4ECDC4,stroke:#333,stroke-width:2px
+    classDef aggregated fill:#FF6B6B,stroke:#333,stroke-width:2px
     ${processNodeIds.length > 0 ? `class ${processNodeIds.join(',')} process` : ''}
     ${sampledTimestamps.length > 0 ? `class ${sampledTimestamps.map((_, index) => `Agg_${index}`).join(',')} aggregated` : ''}`;
 }

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -94,9 +94,9 @@ export function generateCombinedMermaidChart(
         );
     });
 
-    return `%%{init: {'theme': 'base', 'themeVariables': {'primaryTextColor': '#0F172A', 'lineColor': '#475569', 'clusterBkg': '#F8FAFC', 'clusterBorder': '#94A3B8', 'titleColor': '#0F172A'}}}%%
+    return `%%{init: {'theme': 'dark'}}%%
 flowchart LR
-    subgraph Time["JVM Telemetry Over Time"]
+    subgraph Time[" "]
         direction TB
         ${sampledTimestamps.map((timestamp, checkpointIndex) => {
             const processNodes = Array.from(processes.entries()).map(([key, data]) => {
@@ -130,8 +130,8 @@ flowchart LR
         : `    Agg_${checkpointIndex - 1} --> Agg_${checkpointIndex}`
     ).filter(Boolean).join('\n    ')}
 
-    classDef process fill:#D8F3F0,stroke:#0F766E,color:#0F172A,stroke-width:2px
-    classDef aggregated fill:#FEE2E2,stroke:#B91C1C,color:#0F172A,stroke-width:2px
+    classDef process fill:#4ECDC4,stroke:#333,stroke-width:2px
+    classDef aggregated fill:#FF6B6B,stroke:#333,stroke-width:2px
     ${processNodeIds.length > 0 ? `class ${processNodeIds.join(',')} process` : ''}
     ${sampledTimestamps.length > 0 ? `class ${sampledTimestamps.map((_, index) => `Agg_${index}`).join(',')} aggregated` : ''}`;
 }


### PR DESCRIPTION
## Summary

The build-summary Mermaid graph no longer shows the redundant “JVM Telemetry Over Time” heading. Process and aggregate nodes again use the original dark-theme teal and coral palette requested for the graph, while the telemetry content and layout remain unchanged.

## Validation

- `npm test -- --runInBand` — 13 suites and 53 tests passed
- `npm run build`
- `git diff --check`

## Post-Deploy Monitoring & Validation

- Inspect the Mermaid block in the next Build Process Watcher job summary.
- Healthy: no outer graph title; teal process nodes and coral aggregate nodes render with readable labels.
- Failure: Mermaid parse error, missing nodes, or unreadable labels; revert this PR if observed.
- Validation window: first workflow run after deployment; owner: repository maintainer.
