### PR TITLE
fix: improve Mermaid process node contrast

### DIFF
--- a/__tests__/mermaid.test.ts
+++ b/__tests__/mermaid.test.ts
@@ -26,7 +26,7 @@ describe('generateCombinedMermaidChart', () => {
     expect(chart).toContain("'theme': 'dark'");
     expect(chart).toContain('subgraph Time[" "]');
     expect(chart).not.toContain('JVM Telemetry Over Time');
-    expect(chart).toContain('classDef process fill:#4ECDC4,stroke:#333,stroke-width:2px');
+    expect(chart).toContain('classDef process fill:#1D4ED8,stroke:#93C5FD,color:#FFFFFF,stroke-width:2px');
     expect(chart).toContain('classDef aggregated fill:#FF6B6B,stroke:#333,stroke-width:2px');
   });
 

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -215331,7 +215331,7 @@ flowchart LR
         ? ''
         : `    Agg_${checkpointIndex - 1} --> Agg_${checkpointIndex}`).filter(Boolean).join('\n    ')}
 
-    classDef process fill:#4ECDC4,stroke:#333,stroke-width:2px
+    classDef process fill:#1D4ED8,stroke:#93C5FD,color:#FFFFFF,stroke-width:2px
     classDef aggregated fill:#FF6B6B,stroke:#333,stroke-width:2px
     ${processNodeIds.length > 0 ? `class ${processNodeIds.join(',')} process` : ''}
     ${sampledTimestamps.length > 0 ? `class ${sampledTimestamps.map((_, index) => `Agg_${index}`).join(',')} aggregated` : ''}`;

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -130,7 +130,7 @@ flowchart LR
         : `    Agg_${checkpointIndex - 1} --> Agg_${checkpointIndex}`
     ).filter(Boolean).join('\n    ')}
 
-    classDef process fill:#4ECDC4,stroke:#333,stroke-width:2px
+    classDef process fill:#1D4ED8,stroke:#93C5FD,color:#FFFFFF,stroke-width:2px
     classDef aggregated fill:#FF6B6B,stroke:#333,stroke-width:2px
     ${processNodeIds.length > 0 ? `class ${processNodeIds.join(',')} process` : ''}
     ${sampledTimestamps.length > 0 ? `class ${sampledTimestamps.map((_, index) => `Agg_${index}`).join(',')} aggregated` : ''}`;


### PR DESCRIPTION
## Summary

Process metrics in the build-summary Mermaid graph are now readable against GitHub’s dark background. Bright teal process nodes are replaced with dark blue nodes, explicit white text, and a light blue border; aggregate nodes and graph layout remain unchanged.

## Validation

- `npm test -- --runInBand` — 13 suites and 53 tests passed
- `npm run build`
- `git diff --check`

## Post-Deploy Monitoring & Validation

- Inspect the Mermaid block in the next Build Process Watcher job summary.
- Healthy: dark blue process nodes render with white labels and a light blue border.
- Failure: Mermaid parse error, missing nodes, or unreadable labels; revert this PR if observed.
- Validation window: first workflow run after deployment; owner: repository maintainer.