### PR TITLE
fix: unify dashboard metric controls

### DIFF
--- a/__tests__/replay-accessibility.test.ts
+++ b/__tests__/replay-accessibility.test.ts
@@ -34,6 +34,36 @@ describe('remote run dashboard panels', () => {
   });
 });
 
+describe('remote run dashboard metric tools', () => {
+  test.each([
+    '../frontend/public/runs/[runId].html',
+    '../frontend/public/runs/demo.html',
+  ])('%s gives all four metric groups downloads followed by replay', relativePath => {
+    const source = fs.readFileSync(path.join(__dirname, relativePath), 'utf8');
+    const groups = [
+      ['rss', 'btn-download-png', 'btn-download-svg'],
+      ['gc', 'btn-download-gc-png', 'btn-download-gc-svg'],
+      ['jit', 'btn-download-jit-png', 'btn-download-jit-svg'],
+      ['classes', 'btn-download-classes-png', 'btn-download-classes-svg'],
+    ];
+
+    groups.forEach(([panel, pngButton, svgButton]) => {
+      const pngIndex = source.indexOf(`id="${pngButton}"`);
+      const svgIndex = source.indexOf(`id="${svgButton}"`);
+      const replayIndex = source.indexOf(`id="${panel}-replay-controls"`);
+
+      expect(pngIndex).toBeGreaterThan(-1);
+      expect(svgIndex).toBeGreaterThan(pngIndex);
+      expect(replayIndex).toBeGreaterThan(svgIndex);
+    });
+
+    expect(source).toContain("downloadRuntimeChart('jit-time-chart', 'jit', 'png')");
+    expect(source).toContain("downloadRuntimeChart('jit-time-chart', 'jit', 'svg')");
+    expect(source).toContain("downloadRuntimeChart('classes-loaded-chart', 'classes', 'png')");
+    expect(source).toContain("downloadRuntimeChart('classes-loaded-chart', 'classes', 'svg')");
+  });
+});
+
 describe('production replay controls', () => {
   test.each([
     ['Replay', '../frontend/public/replay.js', 'single-replay'],

--- a/frontend/public/runs/[runId].html
+++ b/frontend/public/runs/[runId].html
@@ -981,6 +981,10 @@
                         <button type="button" class="bpw-panel-focus-btn" data-bpw-focus="jit-time" title="Expand this panel">Expand</button>
                     </div>
                     <div class="bpw-panel-card-body">
+                        <div class="downloads-toolbar">
+                            <button class="btn" id="btn-download-jit-png">Download JIT PNG</button>
+                            <button class="btn" id="btn-download-jit-svg">Download JIT SVG</button>
+                        </div>
                         ${isFinished === true ? `
                         <div class="replay-controls" id="jit-replay-controls">
                             <div class="buttons">
@@ -1035,6 +1039,10 @@
                         <button type="button" class="bpw-panel-focus-btn" data-bpw-focus="classes-loaded" title="Expand this panel">Expand</button>
                     </div>
                     <div class="bpw-panel-card-body">
+                        <div class="downloads-toolbar">
+                            <button class="btn" id="btn-download-classes-png">Download Classes PNG</button>
+                            <button class="btn" id="btn-download-classes-svg">Download Classes SVG</button>
+                        </div>
                         ${isFinished === true ? `
                         <div class="replay-controls" id="classes-replay-controls">
                             <div class="buttons">
@@ -1129,6 +1137,10 @@
             const btnCsv = document.getElementById('btn-download-csv');
             const btnGcPng = document.getElementById('btn-download-gc-png');
             const btnGcSvg = document.getElementById('btn-download-gc-svg');
+            const btnJitPng = document.getElementById('btn-download-jit-png');
+            const btnJitSvg = document.getElementById('btn-download-jit-svg');
+            const btnClassesPng = document.getElementById('btn-download-classes-png');
+            const btnClassesSvg = document.getElementById('btn-download-classes-svg');
 
             if (btnPng) btnPng.onclick = () => downloadChart('png');
             if (btnSvg) btnSvg.onclick = () => downloadChart('svg');
@@ -1136,6 +1148,10 @@
             if (btnCsv) btnCsv.onclick = () => downloadCsv(runId);
             if (btnGcPng) btnGcPng.onclick = () => downloadGCChart('png');
             if (btnGcSvg) btnGcSvg.onclick = () => downloadGCChart('svg');
+            if (btnJitPng) btnJitPng.onclick = () => downloadRuntimeChart('jit-time-chart', 'jit', 'png');
+            if (btnJitSvg) btnJitSvg.onclick = () => downloadRuntimeChart('jit-time-chart', 'jit', 'svg');
+            if (btnClassesPng) btnClassesPng.onclick = () => downloadRuntimeChart('classes-loaded-chart', 'classes', 'png');
+            if (btnClassesSvg) btnClassesSvg.onclick = () => downloadRuntimeChart('classes-loaded-chart', 'classes', 'svg');
 
             if (window.BpwExperimentLayout) {
                 if (typeof BpwExperimentLayout.initAfterRunRender === 'function') {
@@ -2468,6 +2484,30 @@
                 a.remove();
             } catch (e) {
                 console.error('Failed to export GC chart:', e);
+            }
+        }
+
+        async function downloadRuntimeChart(chartId, metric, format) {
+            try {
+                const chart = document.getElementById(chartId);
+                const isMobile = window.innerWidth < 768;
+                const filename = `build-monitor-${metric}-${runId}`;
+                const opts = {
+                    format: format,
+                    filename: filename,
+                    height: isMobile ? 400 : 500,
+                    width: isMobile ? 800 : 1000,
+                    scale: 2
+                };
+                const url = await Plotly.toImage(chart, opts);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `${filename}.${format}`;
+                document.body.appendChild(a);
+                a.click();
+                a.remove();
+            } catch (e) {
+                console.error(`Failed to export ${metric} chart:`, e);
             }
         }
 

--- a/frontend/public/runs/demo.html
+++ b/frontend/public/runs/demo.html
@@ -989,6 +989,10 @@
                         <button type="button" class="bpw-panel-focus-btn" data-bpw-focus="jit-time" title="Expand this panel">Expand</button>
                     </div>
                     <div class="bpw-panel-card-body">
+                        <div class="downloads-toolbar">
+                            <button class="btn" id="btn-download-jit-png">Download JIT PNG</button>
+                            <button class="btn" id="btn-download-jit-svg">Download JIT SVG</button>
+                        </div>
                         ${isFinished === true ? `
                         <div class="replay-controls" id="jit-replay-controls">
                             <div class="buttons">
@@ -1043,6 +1047,10 @@
                         <button type="button" class="bpw-panel-focus-btn" data-bpw-focus="classes-loaded" title="Expand this panel">Expand</button>
                     </div>
                     <div class="bpw-panel-card-body">
+                        <div class="downloads-toolbar">
+                            <button class="btn" id="btn-download-classes-png">Download Classes PNG</button>
+                            <button class="btn" id="btn-download-classes-svg">Download Classes SVG</button>
+                        </div>
                         ${isFinished === true ? `
                         <div class="replay-controls" id="classes-replay-controls">
                             <div class="buttons">
@@ -1137,6 +1145,10 @@
             const btnCsv = document.getElementById('btn-download-csv');
             const btnGcPng = document.getElementById('btn-download-gc-png');
             const btnGcSvg = document.getElementById('btn-download-gc-svg');
+            const btnJitPng = document.getElementById('btn-download-jit-png');
+            const btnJitSvg = document.getElementById('btn-download-jit-svg');
+            const btnClassesPng = document.getElementById('btn-download-classes-png');
+            const btnClassesSvg = document.getElementById('btn-download-classes-svg');
 
             if (btnPng) btnPng.onclick = () => downloadChart('png');
             if (btnSvg) btnSvg.onclick = () => downloadChart('svg');
@@ -1144,6 +1156,10 @@
             if (btnCsv) btnCsv.onclick = () => downloadCsv(runId);
             if (btnGcPng) btnGcPng.onclick = () => downloadGCChart('png');
             if (btnGcSvg) btnGcSvg.onclick = () => downloadGCChart('svg');
+            if (btnJitPng) btnJitPng.onclick = () => downloadRuntimeChart('jit-time-chart', 'jit', 'png');
+            if (btnJitSvg) btnJitSvg.onclick = () => downloadRuntimeChart('jit-time-chart', 'jit', 'svg');
+            if (btnClassesPng) btnClassesPng.onclick = () => downloadRuntimeChart('classes-loaded-chart', 'classes', 'png');
+            if (btnClassesSvg) btnClassesSvg.onclick = () => downloadRuntimeChart('classes-loaded-chart', 'classes', 'svg');
 
             if (window.BpwExperimentLayout) {
                 if (typeof BpwExperimentLayout.initAfterRunRender === 'function') {
@@ -2476,6 +2492,30 @@
                 a.remove();
             } catch (e) {
                 console.error('Failed to export GC chart:', e);
+            }
+        }
+
+        async function downloadRuntimeChart(chartId, metric, format) {
+            try {
+                const chart = document.getElementById(chartId);
+                const isMobile = window.innerWidth < 768;
+                const filename = `build-monitor-${metric}-${runId}`;
+                const opts = {
+                    format: format,
+                    filename: filename,
+                    height: isMobile ? 400 : 500,
+                    width: isMobile ? 800 : 1000,
+                    scale: 2
+                };
+                const url = await Plotly.toImage(chart, opts);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `${filename}.${format}`;
+                document.body.appendChild(a);
+                a.click();
+                a.remove();
+            } catch (e) {
+                console.error(`Failed to export ${metric} chart:`, e);
             }
         }
 


### PR DESCRIPTION
## Summary

JIT and Class Loading previously exposed replay controls without the PNG/SVG downloads available for Memory and GC. All four metric groups now use the same download-then-replay structure, and the new exports target the cumulative JIT and class-loading charts in both the live and demo dashboards.

## Validation

- `npm test -- --runInBand` (60 tests passed)
- Added coverage for toolbar ordering and JIT/Class Loading export handlers in both run templates
- `git diff --check`
- Browser visual verification was unavailable in the current session; the supplied production run was used as the behavior reference: https://process-watcher.web.app/runs/run-1783362946859

## Post-Deploy Monitoring & Validation

- Open a completed run with JIT and class-loading data and verify Memory, GC, JIT, and Class Loading each show PNG/SVG downloads before replay controls.
- Exercise both new PNG/SVG pairs and confirm files download with `build-monitor-jit-*` and `build-monitor-classes-*` names.
- Watch the browser console for `Failed to export jit chart` or `Failed to export classes chart`.
- Healthy signal: all four sections retain replay behavior and each export opens or downloads a non-empty image.
- Failure trigger: missing controls, empty exports, or export errors; revert commit `6a21195` if confirmed after deployment.
- Validation window and owner: project maintainer during the first production deployment.
