### PR TITLE
fix: align metric chart presentation

### DIFF
--- a/__tests__/compare-shared.test.ts
+++ b/__tests__/compare-shared.test.ts
@@ -19,6 +19,12 @@ describe('JIT and class loading series', () => {
     expect(shared.hasClassLoadingData([{ ClassesLoaded: 0 }])).toBe(true);
   });
 
+  it('uses an opaque export background for every chart layout', () => {
+    expect(shared.getMemoryLayout().paper_bgcolor).toBe('#ffffff');
+    expect(shared.getGcLayout().paper_bgcolor).toBe('#ffffff');
+    expect(shared.getCounterLayout('Counter', 'Value').paper_bgcolor).toBe('#ffffff');
+  });
+
   it('calculates rates across actual sparse observations', () => {
     const timestamps = [0, 1000, 2000, 5000];
     const samples = [

--- a/__tests__/replay-accessibility.test.ts
+++ b/__tests__/replay-accessibility.test.ts
@@ -64,6 +64,32 @@ describe('remote run dashboard metric tools', () => {
   });
 });
 
+describe('runtime metric panel consistency', () => {
+  test.each([
+    '../frontend/public/runs/[runId].html',
+    '../frontend/public/runs/demo.html',
+    '../frontend/public/replay.js',
+  ])('%s gives every JIT and class loading chart its own chart container', relativePath => {
+    const source = fs.readFileSync(path.join(__dirname, relativePath), 'utf8');
+    const chartIds = relativePath.endsWith('replay.js')
+      ? ['single-jit-time', 'single-jit-rate', 'single-classes-loaded', 'single-class-rate']
+      : ['jit-time-chart', 'jit-rate-chart', 'classes-loaded-chart', 'class-rate-chart'];
+
+    chartIds.forEach(chartId => {
+      expect(source).toMatch(new RegExp(
+        `<div class="chart-container">\\s*<div class="chart-wrapper">\\s*<div id="${chartId}"`,
+      ));
+    });
+  });
+
+  it('renders comparison counter diagrams in separate chart containers', () => {
+    const source = fs.readFileSync(path.join(__dirname, '../frontend/public/compare-shared.js'), 'utf8');
+
+    expect(source).toContain('metrics.map(([id, metricTitle]) => `<div class="chart-container">');
+    expect(source).not.toContain("<div class=\"chart-container\"><h4>${title}</h4>${metrics.map");
+  });
+});
+
 describe('production replay controls', () => {
   test.each([
     ['Replay', '../frontend/public/replay.js', 'single-replay'],

--- a/frontend/public/bpw-experiment.css
+++ b/frontend/public/bpw-experiment.css
@@ -153,7 +153,7 @@ body.bpw-layout-experiment .bpw-runtime-stage {
 }
 
 body.bpw-layout-experiment .bpw-runtime-stage .bpw-chart-panel {
-    grid-column: span 6;
+    grid-column: span 12;
 }
 
 body.bpw-layout-experiment .bpw-runtime-stage .bpw-chart-plot {
@@ -702,7 +702,7 @@ body.bpw-layout-experiment .bpw-chart-panel[data-bpw-panel="jit-time"],
 body.bpw-layout-experiment .bpw-chart-panel[data-bpw-panel="jit-rate"],
 body.bpw-layout-experiment .bpw-chart-panel[data-bpw-panel="classes-loaded"],
 body.bpw-layout-experiment .bpw-chart-panel[data-bpw-panel="class-rate"] {
-    grid-column: span 6;
+    grid-column: span 12;
 }
 
 body.bpw-layout-experiment.bpw-focus-mode .bpw-chart-panel:not(.bpw-panel-focus-active) {

--- a/frontend/public/compare-shared.js
+++ b/frontend/public/compare-shared.js
@@ -805,7 +805,7 @@
         const isMobile = window.innerWidth < 768;
         return {
             title: isMobile ? '' : 'Garbage Collection Time Over Time',
-            paper_bgcolor: 'rgba(0,0,0,0)',
+            paper_bgcolor: '#ffffff',
             plot_bgcolor: '#fbfaf6',
             hovermode: 'x unified',
             xaxis: {
@@ -873,7 +873,7 @@
         const isMobile = window.innerWidth < 768;
         return {
             title: isMobile ? '' : 'Heap/RSS Ratio Over Time',
-            paper_bgcolor: 'rgba(0,0,0,0)',
+            paper_bgcolor: '#ffffff',
             plot_bgcolor: '#fbfaf6',
             hovermode: 'x unified',
             xaxis: {
@@ -932,7 +932,7 @@
         const isMobile = window.innerWidth < 768;
         return {
             title: isMobile ? '' : 'Memory Usage Over Time',
-            paper_bgcolor: 'rgba(0,0,0,0)',
+            paper_bgcolor: '#ffffff',
             plot_bgcolor: '#fbfaf6',
             hovermode: 'x unified',
             xaxis: {
@@ -1249,9 +1249,9 @@
         const compareMode = storedMode === 'side' ? 'side' : 'split';
         const isSplitMode = compareMode === 'split';
         const splitLabel = `${baseLabel} vs ${compareLabel} (Split View)`;
-        const counterPanel = (title, metrics) => isSplitMode
-            ? `<div class="chart-container"><h4>${title}</h4>${metrics.map(([id]) => `<div id="compare-${id}" style="width:100%;height:400px"></div>`).join('')}</div>`
-            : `<div class="compare-grid">${[baseLabel, compareLabel].map((label, index) => `<div class="chart-container"><h4>${title}: ${label}</h4>${metrics.map(([id]) => `<div id="compare-${index === 0 ? 'current' : 'other'}-${id}" style="width:100%;height:400px"></div>`).join('')}</div>`).join('')}</div>`;
+        const counterPanel = (metrics) => isSplitMode
+            ? metrics.map(([id, metricTitle]) => `<div class="chart-container"><h4>${metricTitle}</h4><div class="chart-wrapper"><div id="compare-${id}" style="width:100%;height:400px"></div></div></div>`).join('')
+            : metrics.map(([id, metricTitle]) => `<div class="compare-grid">${[baseLabel, compareLabel].map((label, index) => `<div class="chart-container"><h4>${metricTitle}: ${label}</h4><div class="chart-wrapper"><div id="compare-${index === 0 ? 'current' : 'other'}-${id}" style="width:100%;height:400px"></div></div></div>`).join('')}</div>`).join('');
 
         compareSection.innerHTML = `
             <div class="compare-header">
@@ -1366,8 +1366,14 @@
                 </div>
                 `}
             </div>
-            ${showJIT ? counterPanel('JIT Compilation', [['jit-time'], ['jit-rate']]) : ''}
-            ${showClasses ? counterPanel('Class Loading', [['classes-loaded'], ['class-rate']]) : ''}
+            ${showJIT ? counterPanel([
+                ['jit-time', 'Cumulative JIT Compilation Time'],
+                ['jit-rate', 'JIT Compilation Activity']
+            ]) : ''}
+            ${showClasses ? counterPanel([
+                ['classes-loaded', 'Cumulative Classes Loaded'],
+                ['class-rate', 'Class Loading Activity']
+            ]) : ''}
         `;
 
         compareSection.style.display = 'block';

--- a/frontend/public/replay.js
+++ b/frontend/public/replay.js
@@ -152,7 +152,11 @@
                     <button type="button" class="bpw-panel-focus-btn" data-bpw-focus="jit-time" title="Expand this panel">Expand</button>
                 </div>
                 <div class="bpw-panel-card-body">
-                    <div id="single-jit-time" class="bpw-chart-plot" style="width:100%;height:400px"></div>
+                    <div class="chart-container">
+                        <div class="chart-wrapper">
+                            <div id="single-jit-time" class="bpw-chart-plot" style="width:100%;height:400px"></div>
+                        </div>
+                    </div>
                 </div>
             </div>
             </section>
@@ -166,7 +170,11 @@
                     <button type="button" class="bpw-panel-focus-btn" data-bpw-focus="jit-rate" title="Expand this panel">Expand</button>
                 </div>
                 <div class="bpw-panel-card-body">
-                    <div id="single-jit-rate" class="bpw-chart-plot" style="width:100%;height:400px"></div>
+                    <div class="chart-container">
+                        <div class="chart-wrapper">
+                            <div id="single-jit-rate" class="bpw-chart-plot" style="width:100%;height:400px"></div>
+                        </div>
+                    </div>
                 </div>
             </div>
             </section>` : ''}
@@ -181,7 +189,11 @@
                     <button type="button" class="bpw-panel-focus-btn" data-bpw-focus="classes-loaded" title="Expand this panel">Expand</button>
                 </div>
                 <div class="bpw-panel-card-body">
-                    <div id="single-classes-loaded" class="bpw-chart-plot" style="width:100%;height:400px"></div>
+                    <div class="chart-container">
+                        <div class="chart-wrapper">
+                            <div id="single-classes-loaded" class="bpw-chart-plot" style="width:100%;height:400px"></div>
+                        </div>
+                    </div>
                 </div>
             </div>
             </section>
@@ -195,7 +207,11 @@
                     <button type="button" class="bpw-panel-focus-btn" data-bpw-focus="class-rate" title="Expand this panel">Expand</button>
                 </div>
                 <div class="bpw-panel-card-body">
-                    <div id="single-class-rate" class="bpw-chart-plot" style="width:100%;height:400px"></div>
+                    <div class="chart-container">
+                        <div class="chart-wrapper">
+                            <div id="single-class-rate" class="bpw-chart-plot" style="width:100%;height:400px"></div>
+                        </div>
+                    </div>
                 </div>
             </div>
             </section>` : ''}

--- a/frontend/public/runs/[runId].html
+++ b/frontend/public/runs/[runId].html
@@ -1010,7 +1010,11 @@
                             </div>
                         </div>
                         ` : ''}
-                        <div id="jit-time-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                        <div class="chart-container">
+                            <div class="chart-wrapper">
+                                <div id="jit-time-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 </section>
@@ -1024,7 +1028,11 @@
                         <button type="button" class="bpw-panel-focus-btn" data-bpw-focus="jit-rate" title="Expand this panel">Expand</button>
                     </div>
                     <div class="bpw-panel-card-body">
-                        <div id="jit-rate-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                        <div class="chart-container">
+                            <div class="chart-wrapper">
+                                <div id="jit-rate-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 </section>` : ''}
@@ -1068,7 +1076,11 @@
                             </div>
                         </div>
                         ` : ''}
-                        <div id="classes-loaded-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                        <div class="chart-container">
+                            <div class="chart-wrapper">
+                                <div id="classes-loaded-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 </section>
@@ -1082,7 +1094,11 @@
                         <button type="button" class="bpw-panel-focus-btn" data-bpw-focus="class-rate" title="Expand this panel">Expand</button>
                     </div>
                     <div class="bpw-panel-card-body">
-                        <div id="class-rate-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                        <div class="chart-container">
+                            <div class="chart-wrapper">
+                                <div id="class-rate-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 </section>` : ''}

--- a/frontend/public/runs/demo.html
+++ b/frontend/public/runs/demo.html
@@ -1018,7 +1018,11 @@
                             </div>
                         </div>
                         ` : ''}
-                        <div id="jit-time-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                        <div class="chart-container">
+                            <div class="chart-wrapper">
+                                <div id="jit-time-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 </section>
@@ -1032,7 +1036,11 @@
                         <button type="button" class="bpw-panel-focus-btn" data-bpw-focus="jit-rate" title="Expand this panel">Expand</button>
                     </div>
                     <div class="bpw-panel-card-body">
-                        <div id="jit-rate-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                        <div class="chart-container">
+                            <div class="chart-wrapper">
+                                <div id="jit-rate-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 </section>` : ''}
@@ -1076,7 +1084,11 @@
                             </div>
                         </div>
                         ` : ''}
-                        <div id="classes-loaded-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                        <div class="chart-container">
+                            <div class="chart-wrapper">
+                                <div id="classes-loaded-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 </section>
@@ -1090,7 +1102,11 @@
                         <button type="button" class="bpw-panel-focus-btn" data-bpw-focus="class-rate" title="Expand this panel">Expand</button>
                     </div>
                     <div class="bpw-panel-card-body">
-                        <div id="class-rate-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                        <div class="chart-container">
+                            <div class="chart-wrapper">
+                                <div id="class-rate-chart" class="bpw-chart-plot" style="width:100%;height:450px"></div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 </section>` : ''}


### PR DESCRIPTION
## Summary

Downloaded charts previously used a transparent canvas, which made labels difficult to read outside the dashboard. PNG and SVG exports now use an opaque white background.

JIT and Class Loading now follow the same presentation as Memory and GC: each diagram has its own chart container and full-width section. The same structure is preserved across run dashboards, demo data, replay, and both comparison modes.

## Validation

- `npm test -- --runInBand` — 65 tests passed
- `node --check frontend/public/compare-shared.js`
- `node --check frontend/public/replay.js`
- `git diff --check`
- Added regression coverage for opaque chart layouts and separated runtime metric containers
- Browser visual verification was unavailable in the current session

## Post-Deploy Monitoring & Validation

- Download PNG and SVG files from Memory, GC, JIT, and Class Loading and verify the canvas is white with readable titles, axes, and legends.
- Verify JIT compilation time/activity and Class Loading cumulative/activity diagrams render as separate full-width sections in run and replay views.
- Check split and side-by-side comparison modes for the same separation and ordering.
- Watch the browser console for Plotly render/export errors.
- Healthy signal: all charts render independently and exported labels remain readable.
- Failure trigger: overlapping charts, transparent exports, missing labels, or replay/compare layout regressions; revert commit `5aa4ebc` if confirmed.
- Validation window and owner: project maintainer during the first production deployment.
