### PR TITLE
fix: copy bazel backend binary in docker build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,7 @@ FROM gcr.io/bazel-public/bazel:8.5.0 AS builder
 WORKDIR /workspace
 
 COPY . .
-RUN bazel build //:server && cp -L bazel-bin/server /tmp/main
+RUN bazel build //:server && cp -L bazel-bin/server_/server /tmp/main
 
 # Runtime stage
 FROM alpine:latest


### PR DESCRIPTION
## Summary
- copy the actual Bazel Go binary path from the backend Docker build
- fixes Cloud Run source deploy after Bazel reports bazel-bin/server_/server

## Validation
- bazel build //:server
- git diff --check

## Deploy failure addressed
Latest backend deploy passed tests but failed in Cloud Build because the Dockerfile copied bazel-bin/server, which no longer exists for this go_binary target.