### PR TITLE
fix: copy backend binary from bazel output dir

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,7 @@ FROM gcr.io/bazel-public/bazel:8.5.0 AS builder
 WORKDIR /workspace
 
 COPY . .
-RUN bazel build //:server && cp -L bazel-bin/server_/server /tmp/main
+RUN bazel build //:server && cp -L "$(bazel info bazel-bin)/server_/server" /tmp/main
 
 # Runtime stage
 FROM alpine:latest


### PR DESCRIPTION
## Summary
- copy the backend server binary from Bazel's real output directory instead of the workspace convenience symlink
- avoids Cloud Build failures when bazel-bin cannot be created as a symlink in the uploaded source workspace

## Validation
- bazel build //:server
- git diff --check

## Deploy failure addressed
The latest backend deploy built //:server successfully, but Docker failed because bazel-bin/server_/server did not exist after Bazel could not create convenience symlinks in /workspace.