### PR TITLE
Fix predictive smoke checkpoint count

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -108,7 +108,7 @@ jobs:
           --data @/tmp/ingest-request.json \
           | jq -e '.status == "success"'
 
-        EXPECTED_CHECKPOINTS="$(printf '%s' "$PREDICTIVE_RELIABILITY_CHECKPOINTS" | tr ',' '\n' | sed '/^$/d' | wc -l | tr -d ' ')"
+        EXPECTED_CHECKPOINTS="$(printf '%s' "$PREDICTIVE_RELIABILITY_CHECKPOINTS" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | length')"
         for attempt in $(seq 1 12); do
           curl --fail --silent --show-error "$SERVICE_URL/runs/$RUN_ID" > /tmp/smoke-run.json
           if jq -e --argjson expected "$EXPECTED_CHECKPOINTS" '
@@ -120,14 +120,14 @@ jobs:
           fi
 
           echo "Waiting for predictive checkpoints (${attempt}/12): $(jq -r '
-            "samples=\(.samples | length), checkpoints=\((.prediction_checkpoints // []) | length), statuses=\([(.prediction_checkpoints // [])[]?.status] | join(","))"
+            "samples=\(.samples | length), expected_checkpoints='"$EXPECTED_CHECKPOINTS"', checkpoints=\((.prediction_checkpoints // []) | length), statuses=\([(.prediction_checkpoints // [])[]?.status] | join(","))"
           ' /tmp/smoke-run.json)"
           sleep 5
         done
 
         echo "Predictive checkpoints did not become ready in time."
         jq -r '
-          "samples=\(.samples | length), checkpoints=\((.prediction_checkpoints // []) | length), statuses=\([(.prediction_checkpoints // [])[]?.status] | join(","))"
+          "samples=\(.samples | length), expected_checkpoints='"$EXPECTED_CHECKPOINTS"', checkpoints=\((.prediction_checkpoints // []) | length), statuses=\([(.prediction_checkpoints // [])[]?.status] | join(","))"
         ' /tmp/smoke-run.json
         exit 1
 


### PR DESCRIPTION
Summary: fix the public deploy predictive smoke test checkpoint count for comma-separated checkpoint secrets without requiring a trailing newline, and include the sanitized expected count in retry output. Root cause: the previous wc -l pipeline counted separators/newlines, so a value like 30,60,180 produced expected=2 even though the backend returned three ready checkpoints. Validation: reproduced old count as 2; verified new jq split count as 3; verified corrected assertion against deploy-smoke-30378033780-1; git diff --check; YAML parse check.