### PR TITLE
Require opt-in for predictive reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,13 @@ This is not required for normal local or remote monitoring. Use it only when you
 | `debug` | Enable debug logging | `false` | No |
 | `disable_summary_output` | Disable GitHub Actions summary output | `false` | No |
 | `export_to_bigquery` | Optional metrics export to BigQuery when Remote Mode finishes | `false` | No |
+| `predictive_reliability` | Opt in to private predictive reliability checkpoints for Remote Mode runs | `false` | No |
 
 **Environment variables (for Remote Mode):** Set `BACKEND_URL` and `FRONTEND_URL` as env vars (e.g. from secrets) for custom URLs. If unset, default Cloud Run and dashboard URLs are used.
 
 **BigQuery export is optional:** It is only for collecting metrics in BigQuery. Set `export_to_bigquery: 'true'` together with `remote_monitoring: 'true'` when you want that export. The backend service must be configured with `BIGQUERY_EXPORT_DATASET`; optional table overrides are `BIGQUERY_EXPORT_TABLE` and `BIGQUERY_EXPORT_PROCESSES_TABLE`.
 
-**Predictive reliability is private-provider only:** Public builds keep prediction disabled by default. The backend can carry public-safe `prediction_checkpoints` returned by an injected or remote provider, and the dashboard only renders them when `predictiveReliability` is enabled in `config.js`. Production providers, scoring logic, evaluation artifacts, and customer-specific tuning live outside this public repository.
+**Predictive reliability is opt-in and private-provider only:** Public builds keep prediction disabled by default. Set `predictive_reliability: 'true'` together with `remote_monitoring: 'true'` when you want a run to request private predictive checkpoints. The backend can carry public-safe `prediction_checkpoints` returned by an injected or remote provider, and the dashboard only renders them when `predictiveReliability` is enabled in `config.js`. Production providers, scoring logic, evaluation artifacts, and customer-specific tuning live outside this public repository.
 
 Backend operators can opt in to the private remote provider with:
 

--- a/__tests__/frontend-metadata.test.ts
+++ b/__tests__/frontend-metadata.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const publicDir = path.join(__dirname, '../frontend/public');
+const repoRoot = path.join(__dirname, '..');
 
 const publicPages = [
   { file: 'index.html', canonical: 'https://process-watcher.web.app/' },
@@ -22,6 +23,13 @@ function metaContent(html: string, attribute: 'name' | 'property', value: string
 describe('frontend discovery and social metadata', () => {
   it('keeps predictive reliability disabled in the public config', () => {
     expect(readPage('config.js')).toContain('predictiveReliability: false');
+  });
+
+  it('documents predictive reliability as an opt-in action input', () => {
+    const action = fs.readFileSync(path.join(repoRoot, 'action.yaml'), 'utf8');
+    expect(action).toContain('predictive_reliability:');
+    expect(action).toContain("default: 'false'");
+    expect(readPage('index.html')).toContain('<code>predictive_reliability</code>');
   });
 
   it.each(publicPages)('$file has complete page-specific sharing metadata', ({ file, canonical, noindex }) => {

--- a/action.yaml
+++ b/action.yaml
@@ -30,6 +30,10 @@ inputs:
     description: "Optional metrics export: when true and remote_monitoring is true, ask the backend to export this run's samples to BigQuery when the run finishes (requires BIGQUERY_EXPORT_DATASET on the backend service)"
     required: false
     default: 'false'
+  predictive_reliability:
+    description: "Opt in to private predictive reliability checkpoints when remote_monitoring is true (requires the hosted backend to be configured with a private provider)"
+    required: false
+    default: 'false'
 
 outputs:
   run_id:
@@ -42,6 +46,8 @@ outputs:
     description: 'The frontend dashboard URL for viewing results (only available when remote monitoring is enabled)'
   export_to_bigquery:
     description: 'Whether optional BigQuery metrics export was requested for this run (backend must be configured with BIGQUERY_EXPORT_DATASET)'
+  predictive_reliability:
+    description: 'Whether private predictive reliability checkpoints were requested for this run'
 
 branding:
   icon: "activity"

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -61,6 +62,11 @@ func (h *Handlers) Auth(w http.ResponseWriter, r *http.Request) {
 	if h.storage != nil && r.URL.Query().Get("export_to_bigquery") == "true" {
 		if err := h.storage.SetRunExportToBigquery(runID, true); err != nil {
 			log.Printf("Warning: could not persist export_to_bigquery for run %s: %v", runID, err)
+		}
+	}
+	if h.storage != nil && boolQuery(r, "predictive_reliability") {
+		if err := h.storage.SetRunPredictiveReliability(runID, true); err != nil {
+			log.Printf("Warning: could not persist predictive_reliability for run %s: %v", runID, err)
 		}
 	}
 
@@ -230,6 +236,9 @@ func (h *Handlers) evaluatePredictionCheckpoints(ctx context.Context, runID stri
 		log.Printf("Prediction skipped: could not load run %s: %v", runID, err)
 		return
 	}
+	if !runDoc.PredictiveReliability {
+		return
+	}
 	processDoc, err := h.storage.GetProcesses(runID)
 	if err != nil {
 		log.Printf("Prediction continuing without process info for run %s: %v", runID, err)
@@ -268,6 +277,11 @@ func (h *Handlers) evaluatePredictionCheckpoints(ctx context.Context, runID stri
 			log.Printf("Prediction checkpoint store failed for run %s checkpoint %ds: %v", runID, checkpointWindow, err)
 		}
 	}
+}
+
+func boolQuery(r *http.Request, key string) bool {
+	enabled, err := strconv.ParseBool(strings.TrimSpace(r.URL.Query().Get(key)))
+	return err == nil && enabled
 }
 
 // GetRun retrieves run data

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -41,6 +42,23 @@ func TestIngestHandler_RequestWithProcessInfo(t *testing.T) {
 
 	if len(unmarshaled.ProcessInfo.VMFlags) != 2 {
 		t.Errorf("Expected 2 VM flags, got %d", len(unmarshaled.ProcessInfo.VMFlags))
+	}
+}
+
+func TestBoolQueryAcceptsExplicitTrueOnly(t *testing.T) {
+	request := httptest.NewRequest("POST", "/auth/run/run-1?predictive_reliability=true", nil)
+	if !boolQuery(request, "predictive_reliability") {
+		t.Fatal("expected predictive_reliability=true to be accepted")
+	}
+
+	request = httptest.NewRequest("POST", "/auth/run/run-1?predictive_reliability=false", nil)
+	if boolQuery(request, "predictive_reliability") {
+		t.Fatal("expected predictive_reliability=false to be rejected")
+	}
+
+	request = httptest.NewRequest("POST", "/auth/run/run-1?predictive_reliability=maybe", nil)
+	if boolQuery(request, "predictive_reliability") {
+		t.Fatal("expected invalid predictive_reliability value to be rejected")
 	}
 }
 

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -53,6 +53,7 @@ type RunDoc struct {
 	FinishedAt            time.Time              `firestore:"finished_at,omitempty"`
 	ExpireAt              time.Time              `firestore:"expire_at,omitempty"` // TTL field - set manually in Firestore, used by TTL policy
 	ExportToBigquery      bool                   `firestore:"export_to_bigquery,omitempty"`
+	PredictiveReliability bool                   `firestore:"predictive_reliability,omitempty"`
 	PredictionCheckpoints []PredictionCheckpoint `firestore:"prediction_checkpoints,omitempty"`
 }
 

--- a/backend/internal/models/models_test.go
+++ b/backend/internal/models/models_test.go
@@ -219,6 +219,36 @@ func TestRunResponse_OmitsPredictionCheckpointsWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestRunDoc_PredictiveReliabilityDefaultsFalse(t *testing.T) {
+	var runDoc RunDoc
+	payload := []byte(`{"run_id":"run-1"}`)
+	if err := json.Unmarshal(payload, &runDoc); err != nil {
+		t.Fatal(err)
+	}
+	if runDoc.PredictiveReliability {
+		t.Fatal("PredictiveReliability should default false for legacy runs")
+	}
+}
+
+func TestRunDoc_PredictiveReliabilityRoundTrip(t *testing.T) {
+	runDoc := RunDoc{
+		RunID:                 "run-1",
+		PredictiveReliability: true,
+	}
+	jsonData, err := json.Marshal(runDoc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(jsonData, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw["PredictiveReliability"] != true {
+		t.Fatalf("PredictiveReliability JSON = %v, want true", raw["PredictiveReliability"])
+	}
+}
+
 func TestRunResponse_PredictionCheckpointsRoundTrip(t *testing.T) {
 	riskScore := 42.5
 	peakRSS := 2048.0

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -57,6 +57,25 @@ func (c *Client) SetRunExportToBigquery(runID string, enabled bool) error {
 	return nil
 }
 
+// SetRunPredictiveReliability records that a run opted in to private predictive checkpoints.
+func (c *Client) SetRunPredictiveReliability(runID string, enabled bool) error {
+	if !enabled {
+		return nil
+	}
+	now := time.Now()
+	_, err := c.firestore.Collection("runs").Doc(runID).Set(c.ctx, map[string]interface{}{
+		"run_id":                 runID,
+		"predictive_reliability": true,
+		"updated_at":             now,
+		"updated_at_timestamp":   ToMillis(now),
+	}, firestore.MergeAll)
+	if err != nil {
+		return fmt.Errorf("merge predictive_reliability for run %s: %w", runID, err)
+	}
+	log.Printf("🔮 Marked run %s for predictive reliability checkpoints", runID)
+	return nil
+}
+
 // GetRun retrieves a run document by ID
 func (c *Client) GetRun(runID string) (*models.RunDoc, error) {
 	return c.GetRunWithContext(c.ctx, runID)

--- a/dist/index_with_backend.js
+++ b/dist/index_with_backend.js
@@ -25715,6 +25715,7 @@ async function run() {
         const interval = core.getInput('interval') || '5';
         const disableSummaryOutput = core.getInput('disable_summary_output') === 'true';
         const exportToBigqueryRequested = core.getInput('export_to_bigquery') === 'true';
+        const predictiveReliabilityRequested = core.getInput('predictive_reliability') === 'true';
         // If backend is enabled but no URL provided, use the default Cloud Run URL
         if (enableBackend && !backendUrl) {
             // Default production backend URL
@@ -25725,8 +25726,12 @@ async function run() {
         }
         const useBackend = enableBackend && !!backendUrl;
         const exportToBigquery = exportToBigqueryRequested && useBackend;
+        const predictiveReliability = predictiveReliabilityRequested && useBackend;
         if (exportToBigqueryRequested && !useBackend && debugMode) {
             core.info(`ℹ️  export_to_bigquery is ignored without remote_monitoring and a backend URL`);
+        }
+        if (predictiveReliabilityRequested && !useBackend && debugMode) {
+            core.info(`ℹ️  predictive_reliability is ignored without remote_monitoring and a backend URL`);
         }
         // Show mode and essential info
         const mode = enableBackend ? 'Remote Monitoring' : 'Local Monitoring';
@@ -25766,6 +25771,7 @@ async function run() {
         core.exportVariable('BPW_LOG_FILE_DEFAULT', defaultLogFile.toString());
         core.exportVariable('DISABLE_SUMMARY_OUTPUT', disableSummaryOutput.toString());
         core.exportVariable('EXPORT_TO_BIGQUERY', exportToBigquery ? 'true' : 'false');
+        core.exportVariable('PREDICTIVE_RELIABILITY', predictiveReliability ? 'true' : 'false');
         // Also write RUN_ID to a file as a backup for the post step
         // This ensures the post step can always find the RUN_ID even if env vars aren't available
         try {
@@ -25803,6 +25809,7 @@ async function run() {
         core.setOutput('remote_monitoring', enableBackend.toString());
         core.setOutput('frontend_url', frontendUrl);
         core.setOutput('export_to_bigquery', exportToBigquery.toString());
+        core.setOutput('predictive_reliability', predictiveReliability.toString());
         // Always show the dashboard URL when remote monitoring is enabled (regardless of debug mode)
         if (enableBackend && frontendUrl) {
             core.info(`🌐 Dashboard URL: ${frontendUrl}`);
@@ -25868,6 +25875,7 @@ async function run() {
             DEBUG_MODE: debugMode.toString(),
             REMOTE_MONITORING: (enableBackend && backendUrl) ? 'true' : 'false',
             EXPORT_TO_BIGQUERY: exportToBigquery ? 'true' : 'false',
+            PREDICTIVE_RELIABILITY: predictiveReliability ? 'true' : 'false',
             COLLECT_GC: 'true'
         };
         const child = (0, child_process_1.spawn)(scriptPath, args, {

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -606,6 +606,12 @@
                             <td>No</td>
                         </tr>
                         <tr>
+                            <td><code>predictive_reliability</code></td>
+                            <td>Opt in to private predictive reliability checkpoints for remote runs.</td>
+                            <td><code>false</code></td>
+                            <td>No</td>
+                        </tr>
+                        <tr>
                             <td><code>interval</code></td>
                             <td>Polling interval in seconds.</td>
                             <td><code>5</code></td>

--- a/monitor_with_backend.sh
+++ b/monitor_with_backend.sh
@@ -79,6 +79,7 @@ echo "DEBUG_MODE: $DEBUG_MODE" >> "$SCRIPT_DEBUG_LOG"
 echo "REMOTE_MONITORING: $REMOTE_MONITORING" >> "$SCRIPT_DEBUG_LOG"
 echo "INTERVAL: $INTERVAL" >> "$SCRIPT_DEBUG_LOG"
 echo "EXPORT_TO_BIGQUERY: ${EXPORT_TO_BIGQUERY:-false}" >> "$SCRIPT_DEBUG_LOG"
+echo "PREDICTIVE_RELIABILITY: ${PREDICTIVE_RELIABILITY:-false}" >> "$SCRIPT_DEBUG_LOG"
 echo "PATTERNS: ${PATTERNS[*]}" >> "$SCRIPT_DEBUG_LOG"
 echo "PID: $$" >> "$SCRIPT_DEBUG_LOG"
 echo "" >> "$SCRIPT_DEBUG_LOG"
@@ -180,8 +181,17 @@ get_auth_token() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Requesting auth token for run_id: $RUN_ID" >> "$BACKEND_DEBUG_LOG"
     
     local auth_path="$BACKEND_URL/auth/run/$RUN_ID"
+    local auth_params=()
     if [ "${EXPORT_TO_BIGQUERY:-false}" = "true" ]; then
-        auth_path="${auth_path}?export_to_bigquery=true"
+        auth_params+=("export_to_bigquery=true")
+    fi
+    if [ "${PREDICTIVE_RELIABILITY:-false}" = "true" ]; then
+        auth_params+=("predictive_reliability=true")
+    fi
+    if [ ${#auth_params[@]} -gt 0 ]; then
+        local joined_params
+        joined_params=$(IFS='&'; echo "${auth_params[*]}")
+        auth_path="${auth_path}?${joined_params}"
     fi
     log_script "get_auth_token: Sending POST to $auth_path"
     local auth_response

--- a/src/index_with_backend.ts
+++ b/src/index_with_backend.ts
@@ -32,6 +32,7 @@ async function run() {
     const interval = core.getInput('interval') || '5';
     const disableSummaryOutput = core.getInput('disable_summary_output') === 'true';
     const exportToBigqueryRequested = core.getInput('export_to_bigquery') === 'true';
+    const predictiveReliabilityRequested = core.getInput('predictive_reliability') === 'true';
 
     // If backend is enabled but no URL provided, use the default Cloud Run URL
     if (enableBackend && !backendUrl) {
@@ -44,8 +45,12 @@ async function run() {
 
     const useBackend = enableBackend && !!backendUrl;
     const exportToBigquery = exportToBigqueryRequested && useBackend;
+    const predictiveReliability = predictiveReliabilityRequested && useBackend;
     if (exportToBigqueryRequested && !useBackend && debugMode) {
       core.info(`ℹ️  export_to_bigquery is ignored without remote_monitoring and a backend URL`);
+    }
+    if (predictiveReliabilityRequested && !useBackend && debugMode) {
+      core.info(`ℹ️  predictive_reliability is ignored without remote_monitoring and a backend URL`);
     }
 
     // Show mode and essential info
@@ -90,6 +95,7 @@ async function run() {
     core.exportVariable('BPW_LOG_FILE_DEFAULT', defaultLogFile.toString());
     core.exportVariable('DISABLE_SUMMARY_OUTPUT', disableSummaryOutput.toString());
     core.exportVariable('EXPORT_TO_BIGQUERY', exportToBigquery ? 'true' : 'false');
+    core.exportVariable('PREDICTIVE_RELIABILITY', predictiveReliability ? 'true' : 'false');
     
     // Also write RUN_ID to a file as a backup for the post step
     // This ensures the post step can always find the RUN_ID even if env vars aren't available
@@ -127,6 +133,7 @@ async function run() {
     core.setOutput('remote_monitoring', enableBackend.toString());
     core.setOutput('frontend_url', frontendUrl);
     core.setOutput('export_to_bigquery', exportToBigquery.toString());
+    core.setOutput('predictive_reliability', predictiveReliability.toString());
 
     // Always show the dashboard URL when remote monitoring is enabled (regardless of debug mode)
     if (enableBackend && frontendUrl) {
@@ -200,6 +207,7 @@ async function run() {
       DEBUG_MODE: debugMode.toString(),
       REMOTE_MONITORING: (enableBackend && backendUrl) ? 'true' : 'false',
       EXPORT_TO_BIGQUERY: exportToBigquery ? 'true' : 'false',
+      PREDICTIVE_RELIABILITY: predictiveReliability ? 'true' : 'false',
       COLLECT_GC: 'true'
     };
 


### PR DESCRIPTION
## Summary
- add a public predictive_reliability action input, defaulting to false
- persist the opt-in on the run through the auth request
- gate backend prediction checkpoint evaluation per run, even when the backend provider is configured
- document the opt-in and update the bundled action

## Privacy boundary
This keeps predictive reliability disabled by default for public users. The public backend only calls the private provider when the run explicitly opts in, and no private model internals are added to the public repo.

## Validation
- npm test -- --runInBand
- go test ./... from backend/
- npm run build
- node --check dist/index_with_backend.js
- git diff --check