### PR TITLE
fix: make predictive reliability enable remote export

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ This is not required for normal local or remote monitoring. Use it only when you
 | `debug` | Enable debug logging | `false` | No |
 | `disable_summary_output` | Disable GitHub Actions summary output | `false` | No |
 | `export_to_bigquery` | Optional metrics export to BigQuery when Remote Mode finishes | `false` | No |
-| `predictive_reliability` | Opt in to private predictive reliability checkpoints for Remote Mode runs | `false` | No |
+| `predictive_reliability` | Opt in to private predictive reliability checkpoints; implies Remote Mode and BigQuery export | `false` | No |
 
 **Environment variables (for Remote Mode):** Set `BACKEND_URL` and `FRONTEND_URL` as env vars (e.g. from secrets) for custom URLs. If unset, default Cloud Run and dashboard URLs are used.
 
-**BigQuery export is optional:** It is only for collecting metrics in BigQuery. Set `export_to_bigquery: 'true'` together with `remote_monitoring: 'true'` when you want that export. The backend service must be configured with `BIGQUERY_EXPORT_DATASET`; optional table overrides are `BIGQUERY_EXPORT_TABLE` and `BIGQUERY_EXPORT_PROCESSES_TABLE`.
+**BigQuery export is optional:** It is only for collecting metrics in BigQuery. Set `export_to_bigquery: 'true'` together with `remote_monitoring: 'true'` when you want that export. Predictive reliability also requests BigQuery export automatically. The backend service must be configured with `BIGQUERY_EXPORT_DATASET`; optional table overrides are `BIGQUERY_EXPORT_TABLE` and `BIGQUERY_EXPORT_PROCESSES_TABLE`.
 
-**Predictive reliability is opt-in and private-provider only:** Public builds keep prediction disabled by default. Set `predictive_reliability: 'true'` together with `remote_monitoring: 'true'` when you want a run to request private predictive checkpoints. The backend can carry public-safe `prediction_checkpoints` returned by an injected or remote provider, and the dashboard only renders them when `predictiveReliability` is enabled in `config.js`. Production providers, scoring logic, evaluation artifacts, and customer-specific tuning live outside this public repository.
+**Predictive reliability is opt-in and private-provider only:** Public builds keep prediction disabled by default. Set `predictive_reliability: 'true'` when you want a run to request private predictive checkpoints; this automatically enables Remote Mode and requests BigQuery export for the run. The backend can carry public-safe `prediction_checkpoints` returned by an injected or remote provider, and the dashboard only renders them when `predictiveReliability` is enabled in `config.js`. Production providers, scoring logic, evaluation artifacts, and customer-specific tuning live outside this public repository.
 
 Backend operators can opt in to the private remote provider with:
 

--- a/__tests__/index-with-backend-flags.test.ts
+++ b/__tests__/index-with-backend-flags.test.ts
@@ -1,0 +1,42 @@
+import { resolveMonitoringFeatureFlags } from '../src/monitoring_features';
+
+describe('resolveMonitoringFeatureFlags', () => {
+  it('keeps local mode when no remote-only feature is requested', () => {
+    expect(resolveMonitoringFeatureFlags({
+      remoteMonitoringRequested: false,
+      exportToBigqueryRequested: false,
+      predictiveReliabilityRequested: false,
+      backendUrl: '',
+    })).toEqual({
+      enableBackend: false,
+      exportToBigquery: false,
+      predictiveReliability: false,
+    });
+  });
+
+  it('keeps BigQuery export dependent on an enabled backend', () => {
+    expect(resolveMonitoringFeatureFlags({
+      remoteMonitoringRequested: false,
+      exportToBigqueryRequested: true,
+      predictiveReliabilityRequested: false,
+      backendUrl: 'https://backend.example',
+    })).toEqual({
+      enableBackend: false,
+      exportToBigquery: false,
+      predictiveReliability: false,
+    });
+  });
+
+  it('treats predictive reliability as remote monitoring with BigQuery export', () => {
+    expect(resolveMonitoringFeatureFlags({
+      remoteMonitoringRequested: false,
+      exportToBigqueryRequested: false,
+      predictiveReliabilityRequested: true,
+      backendUrl: 'https://backend.example',
+    })).toEqual({
+      enableBackend: true,
+      exportToBigquery: true,
+      predictiveReliability: true,
+    });
+  });
+});

--- a/action.yaml
+++ b/action.yaml
@@ -27,11 +27,11 @@ inputs:
     required: false
     default: 'false'
   export_to_bigquery:
-    description: "Optional metrics export: when true and remote_monitoring is true, ask the backend to export this run's samples to BigQuery when the run finishes (requires BIGQUERY_EXPORT_DATASET on the backend service)"
+    description: "Optional metrics export: when true and remote_monitoring is true, ask the backend to export this run's samples to BigQuery when the run finishes; also enabled by predictive_reliability (requires BIGQUERY_EXPORT_DATASET on the backend service)"
     required: false
     default: 'false'
   predictive_reliability:
-    description: "Opt in to private predictive reliability checkpoints when remote_monitoring is true (requires the hosted backend to be configured with a private provider)"
+    description: "Opt in to private predictive reliability checkpoints; this enables remote_monitoring and export_to_bigquery for the run (requires the hosted backend to be configured with a private provider)"
     required: false
     default: 'false'
 

--- a/dist/index_with_backend.js
+++ b/dist/index_with_backend.js
@@ -25688,10 +25688,11 @@ const child_process_1 = __nccwpck_require__(5317);
 const fs = __importStar(__nccwpck_require__(9896));
 const path = __importStar(__nccwpck_require__(6928));
 const os = __importStar(__nccwpck_require__(857));
+const monitoring_features_1 = __nccwpck_require__(4647);
 async function run() {
     try {
         let backendUrl = process.env.BACKEND_URL || '';
-        const enableBackend = core.getInput('remote_monitoring') === 'true';
+        const remoteMonitoringRequested = core.getInput('remote_monitoring') === 'true';
         const runId = core.getInput('run_id') || `run-${Date.now()}`;
         const debugMode = core.getInput('debug') === 'true';
         const logFileInput = core.getInput('log_file') || 'build_process_watcher.log';
@@ -25716,22 +25717,27 @@ async function run() {
         const disableSummaryOutput = core.getInput('disable_summary_output') === 'true';
         const exportToBigqueryRequested = core.getInput('export_to_bigquery') === 'true';
         const predictiveReliabilityRequested = core.getInput('predictive_reliability') === 'true';
+        const enableBackendRequested = remoteMonitoringRequested || predictiveReliabilityRequested;
         // If backend is enabled but no URL provided, use the default Cloud Run URL
-        if (enableBackend && !backendUrl) {
+        if (enableBackendRequested && !backendUrl) {
             // Default production backend URL
             backendUrl = 'https://build-process-watcher-backend-685615422311.us-central1.run.app';
             if (debugMode) {
                 core.info(`🔧 Backend enabled but no URL provided, using default URL: ${backendUrl}`);
             }
         }
+        const { enableBackend, exportToBigquery, predictiveReliability, } = (0, monitoring_features_1.resolveMonitoringFeatureFlags)({
+            remoteMonitoringRequested,
+            exportToBigqueryRequested,
+            predictiveReliabilityRequested,
+            backendUrl,
+        });
         const useBackend = enableBackend && !!backendUrl;
-        const exportToBigquery = exportToBigqueryRequested && useBackend;
-        const predictiveReliability = predictiveReliabilityRequested && useBackend;
-        if (exportToBigqueryRequested && !useBackend && debugMode) {
-            core.info(`ℹ️  export_to_bigquery is ignored without remote_monitoring and a backend URL`);
+        if (predictiveReliabilityRequested && debugMode) {
+            core.info(`🔮 predictive_reliability enables remote_monitoring and export_to_bigquery for this run`);
         }
-        if (predictiveReliabilityRequested && !useBackend && debugMode) {
-            core.info(`ℹ️  predictive_reliability is ignored without remote_monitoring and a backend URL`);
+        else if (exportToBigqueryRequested && !useBackend && debugMode) {
+            core.info(`ℹ️  export_to_bigquery is ignored without remote_monitoring and a backend URL`);
         }
         // Show mode and essential info
         const mode = enableBackend ? 'Remote Monitoring' : 'Local Monitoring';
@@ -25933,6 +25939,26 @@ async function run() {
     }
 }
 run();
+
+
+/***/ }),
+
+/***/ 4647:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.resolveMonitoringFeatureFlags = resolveMonitoringFeatureFlags;
+function resolveMonitoringFeatureFlags(inputs) {
+    const enableBackend = inputs.remoteMonitoringRequested || inputs.predictiveReliabilityRequested;
+    const useBackend = enableBackend && !!inputs.backendUrl;
+    return {
+        enableBackend,
+        exportToBigquery: (inputs.exportToBigqueryRequested || inputs.predictiveReliabilityRequested) && useBackend,
+        predictiveReliability: inputs.predictiveReliabilityRequested && useBackend,
+    };
+}
 
 
 /***/ }),

--- a/src/index_with_backend.ts
+++ b/src/index_with_backend.ts
@@ -4,11 +4,12 @@ import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { resolveMonitoringFeatureFlags } from './monitoring_features';
 
 async function run() {
   try {
     let backendUrl = process.env.BACKEND_URL || '';
-    const enableBackend = core.getInput('remote_monitoring') === 'true';
+    const remoteMonitoringRequested = core.getInput('remote_monitoring') === 'true';
     const runId = core.getInput('run_id') || `run-${Date.now()}`;
     const debugMode = core.getInput('debug') === 'true';
     const logFileInput = core.getInput('log_file') || 'build_process_watcher.log';
@@ -34,8 +35,10 @@ async function run() {
     const exportToBigqueryRequested = core.getInput('export_to_bigquery') === 'true';
     const predictiveReliabilityRequested = core.getInput('predictive_reliability') === 'true';
 
+    const enableBackendRequested = remoteMonitoringRequested || predictiveReliabilityRequested;
+
     // If backend is enabled but no URL provided, use the default Cloud Run URL
-    if (enableBackend && !backendUrl) {
+    if (enableBackendRequested && !backendUrl) {
       // Default production backend URL
       backendUrl = 'https://build-process-watcher-backend-685615422311.us-central1.run.app';
       if (debugMode) {
@@ -43,14 +46,22 @@ async function run() {
       }
     }
 
+    const {
+      enableBackend,
+      exportToBigquery,
+      predictiveReliability,
+    } = resolveMonitoringFeatureFlags({
+      remoteMonitoringRequested,
+      exportToBigqueryRequested,
+      predictiveReliabilityRequested,
+      backendUrl,
+    });
     const useBackend = enableBackend && !!backendUrl;
-    const exportToBigquery = exportToBigqueryRequested && useBackend;
-    const predictiveReliability = predictiveReliabilityRequested && useBackend;
-    if (exportToBigqueryRequested && !useBackend && debugMode) {
+
+    if (predictiveReliabilityRequested && debugMode) {
+      core.info(`🔮 predictive_reliability enables remote_monitoring and export_to_bigquery for this run`);
+    } else if (exportToBigqueryRequested && !useBackend && debugMode) {
       core.info(`ℹ️  export_to_bigquery is ignored without remote_monitoring and a backend URL`);
-    }
-    if (predictiveReliabilityRequested && !useBackend && debugMode) {
-      core.info(`ℹ️  predictive_reliability is ignored without remote_monitoring and a backend URL`);
     }
 
     // Show mode and essential info

--- a/src/monitoring_features.ts
+++ b/src/monitoring_features.ts
@@ -1,0 +1,21 @@
+export interface MonitoringFeatureFlags {
+  enableBackend: boolean;
+  exportToBigquery: boolean;
+  predictiveReliability: boolean;
+}
+
+export function resolveMonitoringFeatureFlags(inputs: {
+  remoteMonitoringRequested: boolean;
+  exportToBigqueryRequested: boolean;
+  predictiveReliabilityRequested: boolean;
+  backendUrl: string;
+}): MonitoringFeatureFlags {
+  const enableBackend = inputs.remoteMonitoringRequested || inputs.predictiveReliabilityRequested;
+  const useBackend = enableBackend && !!inputs.backendUrl;
+
+  return {
+    enableBackend,
+    exportToBigquery: (inputs.exportToBigqueryRequested || inputs.predictiveReliabilityRequested) && useBackend,
+    predictiveReliability: inputs.predictiveReliabilityRequested && useBackend,
+  };
+}


### PR DESCRIPTION
## Summary

`predictive_reliability: 'true'` now acts as the full prediction-mode opt-in for the action: it starts Remote Mode and requests BigQuery export even when callers do not also set `remote_monitoring` or `export_to_bigquery`.

The lower-level `export_to_bigquery` flag still requires Remote Mode on its own, so metrics export does not unexpectedly start the hosted backend unless prediction is requested. The action metadata and README now describe that implication directly.

Stacked on: #114

## Validation

- `npm test -- --runInBand`
- `npm run build`
