### PR TITLE
fix: prediction checkpoints are stored but hidden on published dashboard

### DIFF
--- a/__tests__/demo-dashboard.test.ts
+++ b/__tests__/demo-dashboard.test.ts
@@ -12,7 +12,7 @@ describe('demo dashboard', () => {
     expect(html).toContain("fetch('/demo-run.json')");
     expect(html).toContain('Cumulative JIT Compilation Time');
     expect(html).toContain('Class Loading Activity');
-    expect(html).toContain('window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true');
+    expect(html).toContain('window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true || predictionCheckpoints.length > 0');
     expect(html).toContain('prediction_checkpoints');
     expect(html).toContain('predictionHtml');
     expect(html).not.toContain('/runs/${runId}');

--- a/__tests__/run-dashboard-responsive.test.ts
+++ b/__tests__/run-dashboard-responsive.test.ts
@@ -15,9 +15,24 @@ describe('run dashboard responsive layout', () => {
     expect(mobileRules?.[1]).not.toMatch(/\.chart-wrapper\s*{[^}]*min-width:\s*[1-9]\d*px\s*;/);
   });
 
-  it('keeps predictive reliability hidden behind config and data gates', () => {
-    expect(source).toContain('window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true');
+  it('renders predictive reliability when checkpoints are present even if config is disabled', () => {
     expect(source).toContain('prediction_checkpoints');
+    expect(source).toContain('window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true || predictionCheckpoints.length > 0');
     expect(source).toContain('predictionEnabled && predictionCheckpoints.length');
+
+    const predicate = source.match(/const predictionEnabled = ([^;]+);/)?.[1];
+    expect(predicate).toBeDefined();
+
+    const evaluatePredicate = (predictiveReliability: boolean, checkpointCount: number) => Function(
+      'window',
+      'predictionCheckpoints',
+      `return ${predicate};`,
+    )(
+      { BUILD_PROCESS_WATCHER_CONFIG: { predictiveReliability } },
+      { length: checkpointCount },
+    );
+
+    expect(evaluatePredicate(false, 1)).toBe(true);
+    expect(evaluatePredicate(false, 0)).toBe(false);
   });
 });

--- a/frontend/public/runs/[runId].html
+++ b/frontend/public/runs/[runId].html
@@ -662,10 +662,10 @@
             const formatDur = (s) => s < 60 ? s + 's' : (Math.floor(s / 60) + 'm' + (s % 60 ? ' ' + Math.round(s % 60) + 's' : ''));
             const formatPredictionValue = (value, unit) => Number.isFinite(Number(value)) ? `${Number(value).toFixed(Number(value) >= 1000 ? 0 : 1)} ${unit}` : 'N/A';
             const predictionRiskClass = (riskLevel) => ['low', 'elevated', 'high'].includes(riskLevel) ? riskLevel : 'unknown';
-            const predictionEnabled = window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true;
             const predictionCheckpoints = Array.isArray(data.prediction_checkpoints)
                 ? [...data.prediction_checkpoints].sort((a, b) => Number(a.observation_window_s || 0) - Number(b.observation_window_s || 0))
                 : [];
+            const predictionEnabled = window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true || predictionCheckpoints.length > 0;
             const predictionHtml = predictionEnabled && predictionCheckpoints.length ? `
                 <section class="prediction-panel" aria-label="Predictive reliability">
                     <div class="prediction-panel-head">

--- a/frontend/public/runs/demo.html
+++ b/frontend/public/runs/demo.html
@@ -670,10 +670,10 @@
             const formatDur = (s) => s < 60 ? s + 's' : (Math.floor(s / 60) + 'm' + (s % 60 ? ' ' + Math.round(s % 60) + 's' : ''));
             const formatPredictionValue = (value, unit) => Number.isFinite(Number(value)) ? `${Number(value).toFixed(Number(value) >= 1000 ? 0 : 1)} ${unit}` : 'N/A';
             const predictionRiskClass = (riskLevel) => ['low', 'elevated', 'high'].includes(riskLevel) ? riskLevel : 'unknown';
-            const predictionEnabled = window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true;
             const predictionCheckpoints = Array.isArray(data.prediction_checkpoints)
                 ? [...data.prediction_checkpoints].sort((a, b) => Number(a.observation_window_s || 0) - Number(b.observation_window_s || 0))
                 : [];
+            const predictionEnabled = window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true || predictionCheckpoints.length > 0;
             const predictionHtml = predictionEnabled && predictionCheckpoints.length ? `
                 <section class="prediction-panel" aria-label="Predictive reliability">
                     <div class="prediction-panel-head">


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/build-process-watcher#117: Prediction checkpoints are stored but hidden on published dashboard

Fixes #117

## Verification

- `npm test -- --runInBand`