### PR TITLE
fix: opt in deploy predictive smoke

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -89,7 +89,7 @@ jobs:
         fi
 
         RUN_ID="deploy-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-        AUTH_JSON="$(curl --fail --silent --show-error -X POST "$SERVICE_URL/auth/run/$RUN_ID")"
+        AUTH_JSON="$(curl --fail --silent --show-error -X POST "$SERVICE_URL/auth/run/$RUN_ID?predictive_reliability=true")"
         TOKEN="$(printf '%s' "$AUTH_JSON" | jq -r '.token')"
         if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
           echo "Auth response did not include a token."


### PR DESCRIPTION
## Summary
- pass predictive_reliability=true when the deploy workflow runs the predictive checkpoint smoke test
- keep the smoke aligned with the per-run opt-in gate added for published dashboards

## Validation
- ruby YAML parse for .github/workflows/deploy-backend.yml
- git diff --check