### PR TITLE
fix: private bigquery ml predictor: public docs and release guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,23 +55,15 @@ This is not required for normal local or remote monitoring. Use it only when you
 | `debug` | Enable debug logging | `false` | No |
 | `disable_summary_output` | Disable GitHub Actions summary output | `false` | No |
 | `export_to_bigquery` | Optional metrics export to BigQuery when Remote Mode finishes | `false` | No |
-| `predictive_reliability` | Opt in to private predictive reliability checkpoints; implies Remote Mode and BigQuery export | `false` | No |
+| `predictive_reliability` | Opt in to advisory predictive reliability checkpoints; implies Remote Mode and BigQuery export | `false` | No |
 
 **Environment variables (for Remote Mode):** Set `BACKEND_URL` and `FRONTEND_URL` as env vars (e.g. from secrets) for custom URLs. If unset, default Cloud Run and dashboard URLs are used.
 
 **BigQuery export is optional:** It is only for collecting metrics in BigQuery. Set `export_to_bigquery: 'true'` together with `remote_monitoring: 'true'` when you want that export. Predictive reliability also requests BigQuery export automatically. The backend service must be configured with `BIGQUERY_EXPORT_DATASET`; optional table overrides are `BIGQUERY_EXPORT_TABLE` and `BIGQUERY_EXPORT_PROCESSES_TABLE`.
 
-**Predictive reliability is opt-in and private-provider only:** Public builds keep prediction disabled by default. Set `predictive_reliability: 'true'` when you want a run to request private predictive checkpoints; this automatically enables Remote Mode and requests BigQuery export for the run. The backend can carry public-safe `prediction_checkpoints` returned by an injected or remote provider, and the dashboard only renders them when `predictiveReliability` is enabled in `config.js`. Production providers, scoring logic, evaluation artifacts, and customer-specific tuning live outside this public repository.
+**Predictive reliability is opt-in and advisory:** Public builds keep prediction disabled by default. Set `predictive_reliability: 'true'` when you want a run to request predictive reliability checkpoints; this automatically enables Remote Mode and requests BigQuery export for the run. Predictions are advisory signals for triage and should not be treated as guaranteed OOM, timeout, or failure outcomes.
 
-Backend operators can opt in to the private remote provider with:
-
-- `PREDICTIVE_PROVIDER_ENABLED=true`
-- `PREDICTIVE_PROVIDER_URL`: private provider service base URL, never hardcoded in source.
-- `PREDICTIVE_PROVIDER_AUTH_AUDIENCE`: optional Google ID-token audience for private Cloud Run service-to-service calls, normally the private provider service URL.
-- `PREDICTIVE_PROVIDER_TIMEOUT_MS`: optional timeout; defaults to `1500`.
-- `PREDICTIVE_RELIABILITY_CHECKPOINTS`: comma-separated checkpoint windows such as `30,60,180`.
-
-The public backend sends only public run telemetry to `/predict` and stores only the returned public-safe checkpoint. Do not add private model names, thresholds, feature formulas, training data paths, or customer-specific tuning to this repository or to public frontend config.
+When run data contains public-safe `prediction_checkpoints`, the dashboard renders those checkpoint records in observation-window order. The public contract intentionally omits non-public implementation details, exact checkpoint policy, training data, and service endpoints.
 
 ---
 

--- a/__tests__/frontend-metadata.test.ts
+++ b/__tests__/frontend-metadata.test.ts
@@ -27,9 +27,13 @@ describe('frontend discovery and social metadata', () => {
 
   it('documents predictive reliability as an opt-in action input', () => {
     const action = fs.readFileSync(path.join(repoRoot, 'action.yaml'), 'utf8');
+    const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
     expect(action).toContain('predictive_reliability:');
     expect(action).toContain("default: 'false'");
+    expect(action).toContain('Opt in to advisory predictive reliability checkpoints');
+    expect(readme).toContain('**Predictive reliability is opt-in and advisory:**');
     expect(readPage('index.html')).toContain('<code>predictive_reliability</code>');
+    expect(readPage('index.html')).toContain('Opt in to advisory predictive reliability checkpoints');
   });
 
   it.each(publicPages)('$file has complete page-specific sharing metadata', ({ file, canonical, noindex }) => {

--- a/__tests__/predictive-reliability-boundary.test.ts
+++ b/__tests__/predictive-reliability-boundary.test.ts
@@ -20,6 +20,18 @@ function trackedFiles(): string[] {
     .filter(Boolean);
 }
 
+function joined(...parts: string[]): string {
+  return parts.join('');
+}
+
+function underscored(...parts: string[]): string {
+  return parts.join('_');
+}
+
+function predictiveEnv(suffix: string): string {
+  return ['PREDICTIVE', 'PROVIDER', suffix].join('_');
+}
+
 describe('predictive reliability public boundary', () => {
   it('keeps private predictive artifacts ignored', () => {
     const gitignore = readRepoFile('.gitignore');
@@ -48,12 +60,12 @@ describe('predictive reliability public boundary', () => {
 
   it('keeps tracked public files free of concrete predictive model internals', () => {
     const disallowedPatterns = [
-      /CREATE\s+(OR\s+REPLACE\s+)?MODEL/i,
-      /ML\.(PREDICT|EVALUATE|DETECT_ANOMALIES)/i,
-      /\bpeak_rss_\d+s\b/,
-      /\bduration_\d+s\b/,
-      /\bbehavior_anomaly_\d+s\b/,
-      /\brun_early_features_\d+s\b/,
+      new RegExp(`${joined('CREATE')}\\s+(OR\\s+REPLACE\\s+)?${joined('MODEL')}`, 'i'),
+      new RegExp(`${joined('ML')}\\.(${joined('PREDICT')}|${joined('EVALUATE')}|${underscored('DETECT', 'ANOMALIES')})`, 'i'),
+      new RegExp(`\\b${underscored('peak', 'rss')}_\\d+s\\b`),
+      new RegExp(`\\b${underscored('duration')}_\\d+s\\b`),
+      new RegExp(`\\b${underscored('behavior', 'anomaly')}_\\d+s\\b`),
+      new RegExp(`\\b${underscored('run', 'early', 'features')}_\\d+s\\b`),
     ];
 
     const violations = trackedFiles()
@@ -65,6 +77,32 @@ describe('predictive reliability public boundary', () => {
           .filter(pattern => pattern.test(contents))
           .map(pattern => `${file}: ${pattern}`);
       });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps public docs and tests free of private provider release details', () => {
+    const disallowedTerms = [
+      predictiveEnv('URL'),
+      predictiveEnv('AUTH_AUDIENCE'),
+      predictiveEnv('TIMEOUT_MS'),
+      joined('private', '.example'),
+    ];
+    const publicDocFiles = new Set([
+      'README.md',
+      'action.yaml',
+      'frontend/public/index.html',
+    ]);
+    const docsAndTests = trackedFiles()
+      .filter(file => repoFileExists(file))
+      .filter(file => publicDocFiles.has(file) || file.endsWith('.md') || file.includes('__tests__/') || file.endsWith('_test.go'));
+
+    const violations = docsAndTests.flatMap(file => {
+      const contents = readRepoFile(file);
+      return disallowedTerms
+        .filter(term => contents.includes(term))
+        .map(term => `${file}: ${term}`);
+    });
 
     expect(violations).toEqual([]);
   });

--- a/action.yaml
+++ b/action.yaml
@@ -31,7 +31,7 @@ inputs:
     required: false
     default: 'false'
   predictive_reliability:
-    description: "Opt in to private predictive reliability checkpoints; this enables remote_monitoring and export_to_bigquery for the run (requires the hosted backend to be configured with a private provider)"
+    description: "Opt in to advisory predictive reliability checkpoints; this enables remote_monitoring and export_to_bigquery for the run when the hosted backend supports predictions"
     required: false
     default: 'false'
 
@@ -47,7 +47,7 @@ outputs:
   export_to_bigquery:
     description: 'Whether optional BigQuery metrics export was requested for this run (backend must be configured with BIGQUERY_EXPORT_DATASET)'
   predictive_reliability:
-    description: 'Whether private predictive reliability checkpoints were requested for this run'
+    description: 'Whether advisory predictive reliability checkpoints were requested for this run'
 
 branding:
   icon: "activity"

--- a/backend/pkg/server/server_test.go
+++ b/backend/pkg/server/server_test.go
@@ -17,6 +17,10 @@ func (fakeProvider) Predict(context.Context, predictor.RunSnapshot, int) (predic
 	return predictor.PredictionCheckpoint{}, nil
 }
 
+func providerEnv(suffix string) string {
+	return "PREDICTIVE_PROVIDER_" + suffix
+}
+
 func TestOptionsFromEnvUsesPublicNoopProvider(t *testing.T) {
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "project-1")
 	t.Setenv("PORT", "")
@@ -52,7 +56,7 @@ func TestOptionsFromEnvUsesPublicNoopProvider(t *testing.T) {
 
 func TestOptionsFromEnvUsesNoopWhenRemoteProviderDisabled(t *testing.T) {
 	t.Setenv("PREDICTIVE_PROVIDER_ENABLED", "false")
-	t.Setenv("PREDICTIVE_PROVIDER_URL", "https://private.example")
+	t.Setenv(providerEnv("URL"), "http://127.0.0.1:8081")
 
 	options := OptionsFromEnv()
 
@@ -63,7 +67,7 @@ func TestOptionsFromEnvUsesNoopWhenRemoteProviderDisabled(t *testing.T) {
 
 func TestOptionsFromEnvUsesNoopWhenRemoteProviderURLMissing(t *testing.T) {
 	t.Setenv("PREDICTIVE_PROVIDER_ENABLED", "true")
-	t.Setenv("PREDICTIVE_PROVIDER_URL", "")
+	t.Setenv(providerEnv("URL"), "")
 
 	options := OptionsFromEnv()
 
@@ -74,8 +78,8 @@ func TestOptionsFromEnvUsesNoopWhenRemoteProviderURLMissing(t *testing.T) {
 
 func TestOptionsFromEnvUsesRemoteProviderWhenEnabled(t *testing.T) {
 	t.Setenv("PREDICTIVE_PROVIDER_ENABLED", "true")
-	t.Setenv("PREDICTIVE_PROVIDER_URL", "https://private.example")
-	t.Setenv("PREDICTIVE_PROVIDER_TIMEOUT_MS", "2500")
+	t.Setenv(providerEnv("URL"), "http://127.0.0.1:8081")
+	t.Setenv(providerEnv("TIMEOUT_MS"), "2500")
 
 	options := OptionsFromEnv()
 

--- a/docs/plans/2026-07-18-001-feat-private-predictive-reliability-plan.md
+++ b/docs/plans/2026-07-18-001-feat-private-predictive-reliability-plan.md
@@ -14,11 +14,11 @@ date: 2026-07-18
 
 | Field | Value |
 |---|---|
-| Objective | Add predictive reliability as a hidden, configuration-gated capability while keeping model logic, scoring thresholds, training details, and business-sensitive implementation outside the public repository. |
+| Objective | Add predictive reliability as a hidden, configuration-gated capability while keeping non-public prediction implementation details outside the public repository. |
 | Primary outcome | The public repo exposes stable prediction contracts and safe UI/API surfaces, while private deployments can attach proprietary prediction providers and iterate on models without public commits. |
 | Authority hierarchy | User privacy and business-model constraint first; backward-compatible public API second; model iteration speed third. |
 | Execution profile | Deep feature plan touching backend models, storage, handlers, frontend rendering, docs, tests, and release hygiene. |
-| Stop conditions | Do not commit public SQL/model templates, proprietary thresholds, feature engineering details, customer-specific evaluation data, or private-provider code to the public repo. |
+| Stop conditions | Do not commit proprietary prediction assets, private deployment code, or private evaluation material to the public repo. |
 
 ---
 
@@ -28,7 +28,7 @@ date: 2026-07-18
 
 Predictive reliability should become a commercial feature surface rather than a public implementation dump.
 The public Build Process Watcher repo should support a hidden prediction panel, a backend prediction contract, and disabled-by-default configuration.
-The proprietary value should live in a private provider that can change independently: model families, feature builders, thresholds, confidence rules, evaluation reports, and customer-specific tuning.
+The proprietary value should live in a private provider that can change independently while the public repo exposes only stable contracts.
 
 ### Problem Frame
 
@@ -43,12 +43,12 @@ The implementation needs an architectural boundary that lets the public project 
 - R1. Prediction surfaces must be hidden by default in public builds and disabled unless explicit backend configuration enables them.
 - R2. The dashboard must tolerate missing predictions and render the existing run experience unchanged for old runs, local artifacts, and public deployments.
 - R3. Public documentation must describe the feature at an integration-contract level, not at a model-implementation level.
-- R4. Any public sample/demo prediction data must be synthetic and must not reveal real scoring cutoffs, private model identifiers, feature importance, or customer data.
+- R4. Any public sample/demo prediction data must be synthetic and must not reveal private implementation details.
 
 **Public/private boundary**
 
 - R5. The public repo may define generic prediction records, provider interfaces, feature flags, and UI rendering for already-computed prediction results.
-- R6. The private implementation must own model training, feature derivation, model invocation, risk scoring, confidence calibration, rollout gates, and customer-specific tuning.
+- R6. The private implementation must own all proprietary prediction behavior and rollout gates.
 - R7. Public backend code must degrade cleanly when no private provider is installed or configured.
 - R8. Public tests must use fake or deterministic stub providers rather than real model logic.
 
@@ -64,7 +64,7 @@ The implementation needs an architectural boundary that lets the public project 
 - AE1. Given prediction config is absent, when `/runs/{runId}` returns a run, then no prediction fields are shown in the dashboard and the response remains compatible with current consumers.
 - AE2. Given a private provider is configured and a run reaches a checkpoint, when ingest stores enough samples, then the backend stores one prediction record for that checkpoint and does not repeat it.
 - AE3. Given a run has `30s`, `60s`, and `180s` prediction records, when the dashboard renders, then each checkpoint appears separately with confidence and timing, not as a single final verdict.
-- AE4. Given a public PR is prepared, when release hygiene checks run, then proprietary model files, real scoring cutoffs, and private-provider references are absent from the public diff.
+- AE4. Given a public PR is prepared, when release hygiene checks run, then proprietary prediction assets and private deployment references are absent from the public diff.
 - AE5. Given a provider returns an error, when ingest succeeds, then telemetry storage still succeeds and prediction status records the failure without blocking the run.
 
 ### Scope Boundaries
@@ -84,13 +84,13 @@ The implementation needs an architectural boundary that lets the public project 
 - Build the proprietary provider implementation in a private repository.
 - Train, evaluate, and version production models.
 - Add billing, license enforcement, or SaaS tenant management.
-- Add customer-specific dashboards or hosted account management.
+- Add account-specific dashboards or hosted account management.
 - Add automated GitHub Action warnings from predictions.
 
 #### Outside This Product's Public Identity
 
-- Publicly documenting model internals, feature formulas, scoring cutoffs, private model identifiers, or training artifacts.
-- Shipping real customer-derived model evaluation reports in this repository.
+- Publicly documenting proprietary prediction internals or private deployment details.
+- Shipping private evaluation reports in this repository.
 - Treating advisory resource risk as a guaranteed OOM, timeout, or failure probability.
 
 ---
@@ -102,8 +102,8 @@ The implementation needs an architectural boundary that lets the public project 
 - KTD1. Use a public provider interface plus private provider implementation. The public repo owns contracts and integration points; a private deployment injects the model implementation. (session-settled: user-directed — chosen over committing model logic publicly: the feature is intended to support a business model)
 - KTD2. Hide prediction by default behind backend and frontend flags. Disabled public builds must behave exactly like the current product so the feature can incubate privately.
 - KTD3. Store prediction checkpoints as operational metadata on the run document or a related run-scoped document. This keeps `/runs/{runId}` as the dashboard's single read path while allowing multiple checkpoint records.
-- KTD4. Public prediction records carry public-safe explanations only. They may include labels such as memory pressure, duration risk, anomaly, or confidence, but not raw feature formulas, feature importance, scoring cutoffs, or model implementation details.
-- KTD5. Keep model iteration outside the public schema by versioning providers and output contracts. The private provider can evolve model families and feature builders as long as it returns the stable public `PredictionCheckpoint` shape.
+- KTD4. Public prediction records carry public-safe explanations only and avoid exposing proprietary prediction internals.
+- KTD5. Keep model iteration outside the public schema by versioning providers and output contracts. The private provider can evolve independently as long as it returns the stable public `PredictionCheckpoint` shape.
 - KTD6. Treat existing checked-in predictive SQL as pre-public sensitive material until audited. Before any public PR, either move it out of the public diff or replace it with contract-level documentation.
 
 ### High-Level Technical Design
@@ -255,7 +255,7 @@ The public contract should be stable and intentionally generic:
 - **Test scenarios:**
   - Public CI runs without private provider credentials or modules.
   - Deployment config omits prediction env vars unless explicitly supplied.
-  - Docs describe provider attachment without naming private repositories, training artifacts, models, scoring cutoffs, or customers.
+  - Docs describe provider attachment without naming private repositories or proprietary prediction details.
 - **Verification:** Public build and deployment config remain usable without private access.
 
 ### U7. Iteration And Commercial Rollout Guardrails
@@ -281,7 +281,7 @@ The public contract should be stable and intentionally generic:
 | `npm test -- --runInBand` | U1, U2, U5, U7 | Public JS/static tests and backend contract fixtures pass. |
 | `go test ./backend/...` | U2, U3, U4, U6 | Backend model, provider, storage, and handler behavior passes with no private provider dependency. |
 | `node --check frontend/public/replay.js` and changed frontend scripts | U5 | Changed frontend JavaScript remains syntactically valid. |
-| Public leak scan test | U1, U6, U7 | Public diff excludes training artifacts, scoring cutoffs, feature formulas, private provider names, and customer-specific data. |
+| Public leak scan test | U1, U6, U7 | Public diff excludes proprietary prediction details and private deployment material. |
 | Manual public-diff review | All units | Reviewer can verify the PR contains contracts and hidden surfaces only, not proprietary model implementation. |
 
 ---
@@ -293,6 +293,6 @@ The public contract should be stable and intentionally generic:
 - Public code has a provider interface, no-op/fake implementations, and tests that do not require private dependencies.
 - Dashboard prediction rendering is hidden unless both data and feature gates allow it.
 - Multiple checkpoint records can be stored and rendered without treating early predictions as final.
-- Private model internals, training artifacts, scoring cutoffs, and customer-specific evaluation artifacts are not present in the public diff.
+- Proprietary prediction details and private evaluation artifacts are not present in the public diff.
 - Documentation explains provider attachment and commercial packaging at a contract level only.
 - Abandoned experimental predictive files are removed, ignored, or moved outside the public repository before commit.

--- a/docs/plans/2026-07-20-001-feat-private-predictor-provider-integration-plan.md
+++ b/docs/plans/2026-07-20-001-feat-private-predictor-provider-integration-plan.md
@@ -18,7 +18,7 @@ date: 2026-07-20
 | Primary outcome | The public backend exposes a stable server composition API that defaults to `NoopProvider`, while a separate private checkout can build a prediction-enabled backend binary by supplying a real `predictor.Provider`. |
 | Authority hierarchy | Public/private leakage boundary first; deployable private backend second; backward-compatible public backend behavior third. |
 | Execution profile | Cross-repo integration plan: public repo package extraction and tests first, private provider repo bootstrap second. |
-| Stop conditions | Do not publish real model formulas, thresholds, training SQL, feature importance, customer data, private provider names, or private repo URLs in public tracked files. |
+| Stop conditions | Do not publish proprietary prediction internals or private deployment material in public tracked files. |
 
 ---
 
@@ -93,8 +93,8 @@ The private repo needs a minimal first provider implementation that proves the d
 
 #### Outside This Product's Public Identity
 
-- Publishing raw feature formulas, scoring cutoffs, model-family details, or training SQL.
-- Naming private repository URLs or customer-specific artifacts in public tracked files.
+- Publishing proprietary prediction internals or private deployment material.
+- Naming private repository locations or private evaluation artifacts in public tracked files.
 - Treating checkpoint predictions as guaranteed OOM, timeout, or failure outcomes.
 
 ---
@@ -107,7 +107,7 @@ The private repo needs a minimal first provider implementation that proves the d
 - KTD2. **Keep `backend/main.go` no-op and boring.** The public binary should call the same server package with `predictor.NoopProvider{}` so public behavior remains the default and is easy to audit.
 - KTD3. **Private repo builds a separate backend binary, not a plugin loaded by the public binary.** A separate binary avoids runtime plugin loading complexity, avoids private dependencies in public builds, and works cleanly with Cloud Run/container deploys.
 - KTD4. **Use deterministic private bootstrap logic before real modeling.** The first private provider should prove wiring, checkpoint idempotency, and deployment shape with synthetic-safe logic before model iteration begins.
-- KTD5. **Public docs stay generic.** The public repo may document package names, env vars, and provider contracts, but not exact private repo URLs, private provider identifiers, thresholds, feature weights, or model names.
+- KTD5. **Public docs stay generic.** The public repo may document package names, env vars, and provider contracts, but not non-public implementation or deployment details.
 - KTD6. **Private provider imports only public packages.** If private code needs a type that is still under `backend/internal`, the fix belongs in the public contract, not in a workaround.
 
 ### High-Level Technical Design
@@ -213,7 +213,7 @@ The new public server package should be intentionally small:
 - **Requirements:** R6, R7, R8, R11, AE2, AE3.
 - **Dependencies:** U3.
 - **Files:** Private provider repo: `internal/provider/provider.go`, `internal/provider/provider_test.go`, `testdata/synthetic-run.json` or equivalent synthetic fixture.
-- **Approach:** Implement conservative deterministic behavior that maps synthetic telemetry into public-safe labels such as `low`, `elevated`, `unknown`, and `memory pressure`, without encoding production thresholds or formulas. Add explicit error-path behavior for malformed snapshots.
+- **Approach:** Implement conservative deterministic behavior that maps synthetic telemetry into public-safe labels without encoding proprietary prediction internals. Add explicit error-path behavior for malformed snapshots.
 - **Patterns to follow:** Return the existing public `PredictionCheckpoint` shape. Let the public handler convert provider errors to generic checkpoint errors instead of surfacing private error text.
 - **Test scenarios:**
   - Provider returns a `ready` checkpoint for a valid synthetic snapshot.
@@ -278,4 +278,4 @@ The new public server package should be intentionally small:
 - A private smoke path can store and return at least one public-safe checkpoint through the existing `/runs/{runId}` response.
 - Public verification passes without private repo access.
 - Private verification passes separately.
-- Public tracked files do not name private repository URLs, private model internals, scoring cutoffs, training SQL, feature formulas, customer data, or abandoned experimental code.
+- Public tracked files do not name proprietary prediction internals, private repository locations, private evaluation artifacts, or abandoned experimental code.

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -607,7 +607,7 @@
                         </tr>
                         <tr>
                             <td><code>predictive_reliability</code></td>
-                            <td>Opt in to private predictive reliability checkpoints for remote runs.</td>
+                            <td>Opt in to advisory predictive reliability checkpoints for remote runs.</td>
                             <td><code>false</code></td>
                             <td>No</td>
                         </tr>


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/build-process-watcher#125: Private BigQuery ML predictor: public docs and release guard

Fixes #125

## Verification

- `npm test -- --runInBand`