### PR TITLE
feat: default predictive checkpoint windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ This is not required for normal local or remote monitoring. Use it only when you
 
 When run data contains public-safe `prediction_checkpoints`, the dashboard renders those checkpoint records in observation-window order. The public contract intentionally omits non-public implementation details, exact checkpoint policy, training data, and service endpoints.
 
+`PREDICTIVE_RELIABILITY_CHECKPOINTS` can set a comma-separated checkpoint window list. When a production provider is enabled and this value is empty, the backend uses `60,300,600,1200`.
+
+The public backend sends only public run telemetry to `/predict` and stores only the returned public-safe checkpoint. Do not add private model names, thresholds, feature formulas, training data paths, or customer-specific tuning to this repository or to public frontend config.
+
 ---
 
 ## 🧭 Behavior Matrix

--- a/backend/pkg/predictor/predictor.go
+++ b/backend/pkg/predictor/predictor.go
@@ -14,6 +14,8 @@ type Sample = models.Sample
 type ProcessInfo = models.ProcessInfo
 type PredictionCheckpoint = models.PredictionCheckpoint
 
+var defaultCheckpoints = []int{60, 300, 600, 1200}
+
 // RunSnapshot is the public input contract passed to prediction providers.
 type RunSnapshot struct {
 	RunID                 string
@@ -55,6 +57,13 @@ func Enabled(provider Provider) bool {
 	default:
 		return true
 	}
+}
+
+// DefaultCheckpoints returns the public v1 checkpoint windows.
+func DefaultCheckpoints() []int {
+	checkpoints := make([]int, len(defaultCheckpoints))
+	copy(checkpoints, defaultCheckpoints)
+	return checkpoints
 }
 
 // PendingCheckpoints returns configured windows reached by samples and not yet stored.

--- a/backend/pkg/predictor/predictor_test.go
+++ b/backend/pkg/predictor/predictor_test.go
@@ -51,6 +51,24 @@ func TestEnabled(t *testing.T) {
 	}
 }
 
+func TestDefaultCheckpoints(t *testing.T) {
+	checkpoints := DefaultCheckpoints()
+	expected := []int{60, 300, 600, 1200}
+	if len(checkpoints) != len(expected) {
+		t.Fatalf("checkpoints = %v, want %v", checkpoints, expected)
+	}
+	for i := range expected {
+		if checkpoints[i] != expected[i] {
+			t.Fatalf("checkpoints = %v, want %v", checkpoints, expected)
+		}
+	}
+
+	checkpoints[0] = 1
+	if got := DefaultCheckpoints()[0]; got != 60 {
+		t.Fatalf("DefaultCheckpoints returned shared storage; first = %d, want 60", got)
+	}
+}
+
 func TestPendingCheckpointsReturnsReachedMissingWindows(t *testing.T) {
 	pending := PendingCheckpoints(
 		[]Sample{{ElapsedTime: 10}, {ElapsedTime: 75}},

--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -44,6 +44,11 @@ func OptionsFromEnv() Options {
 			log.Printf("🔮 Remote predictive provider disabled: %v", err)
 		}
 	}
+	predictionCheckpointsValue := strings.TrimSpace(os.Getenv("PREDICTIVE_RELIABILITY_CHECKPOINTS"))
+	predictionCheckpoints := predictor.ParseCheckpoints(predictionCheckpointsValue)
+	if predictionCheckpointsValue == "" && predictor.Enabled(predictionProvider) {
+		predictionCheckpoints = predictor.DefaultCheckpoints()
+	}
 
 	return Options{
 		ProjectID:              strings.TrimSpace(os.Getenv("GOOGLE_CLOUD_PROJECT")),
@@ -52,7 +57,7 @@ func OptionsFromEnv() Options {
 		BigQueryTable:          strings.TrimSpace(os.Getenv("BIGQUERY_EXPORT_TABLE")),
 		BigQueryProcessesTable: strings.TrimSpace(os.Getenv("BIGQUERY_EXPORT_PROCESSES_TABLE")),
 		PredictionProvider:     predictionProvider,
-		PredictionCheckpoints:  predictor.ParseCheckpoints(os.Getenv("PREDICTIVE_RELIABILITY_CHECKPOINTS")),
+		PredictionCheckpoints:  predictionCheckpoints,
 	}
 }
 

--- a/backend/pkg/server/server_test.go
+++ b/backend/pkg/server/server_test.go
@@ -57,29 +57,38 @@ func TestOptionsFromEnvUsesPublicNoopProvider(t *testing.T) {
 func TestOptionsFromEnvUsesNoopWhenRemoteProviderDisabled(t *testing.T) {
 	t.Setenv("PREDICTIVE_PROVIDER_ENABLED", "false")
 	t.Setenv(providerEnv("URL"), "http://127.0.0.1:8081")
+	t.Setenv("PREDICTIVE_RELIABILITY_CHECKPOINTS", "")
 
 	options := OptionsFromEnv()
 
 	if predictor.Enabled(options.PredictionProvider) {
 		t.Fatal("provider should remain no-op when remote feature flag is false")
 	}
+	if len(options.PredictionCheckpoints) != 0 {
+		t.Fatalf("PredictionCheckpoints = %v, want empty", options.PredictionCheckpoints)
+	}
 }
 
 func TestOptionsFromEnvUsesNoopWhenRemoteProviderURLMissing(t *testing.T) {
 	t.Setenv("PREDICTIVE_PROVIDER_ENABLED", "true")
 	t.Setenv(providerEnv("URL"), "")
+	t.Setenv("PREDICTIVE_RELIABILITY_CHECKPOINTS", "")
 
 	options := OptionsFromEnv()
 
 	if predictor.Enabled(options.PredictionProvider) {
 		t.Fatal("provider should remain no-op when remote URL is missing")
 	}
+	if len(options.PredictionCheckpoints) != 0 {
+		t.Fatalf("PredictionCheckpoints = %v, want empty", options.PredictionCheckpoints)
+	}
 }
 
-func TestOptionsFromEnvUsesRemoteProviderWhenEnabled(t *testing.T) {
+func TestOptionsFromEnvUsesRemoteProviderWithDefaultCheckpointsWhenEnabled(t *testing.T) {
 	t.Setenv("PREDICTIVE_PROVIDER_ENABLED", "true")
 	t.Setenv(providerEnv("URL"), "http://127.0.0.1:8081")
 	t.Setenv(providerEnv("TIMEOUT_MS"), "2500")
+	t.Setenv("PREDICTIVE_RELIABILITY_CHECKPOINTS", "")
 
 	options := OptionsFromEnv()
 
@@ -88,6 +97,47 @@ func TestOptionsFromEnvUsesRemoteProviderWhenEnabled(t *testing.T) {
 	}
 	if _, ok := options.PredictionProvider.(*predictor.RemoteProvider); !ok {
 		t.Fatalf("provider type = %T, want *predictor.RemoteProvider", options.PredictionProvider)
+	}
+	expected := []int{60, 300, 600, 1200}
+	if got := options.PredictionCheckpoints; len(got) != len(expected) {
+		t.Fatalf("PredictionCheckpoints = %v, want %v", got, expected)
+	} else {
+		for i := range expected {
+			if got[i] != expected[i] {
+				t.Fatalf("PredictionCheckpoints = %v, want %v", got, expected)
+			}
+		}
+	}
+}
+
+func TestOptionsFromEnvKeepsExplicitCheckpointsWhenRemoteProviderEnabled(t *testing.T) {
+	t.Setenv("PREDICTIVE_PROVIDER_ENABLED", "true")
+	t.Setenv(providerEnv("URL"), "http://127.0.0.1:8081")
+	t.Setenv("PREDICTIVE_RELIABILITY_CHECKPOINTS", "30,60,bad,60")
+
+	options := OptionsFromEnv()
+
+	expected := []int{30, 60}
+	if got := options.PredictionCheckpoints; len(got) != len(expected) {
+		t.Fatalf("PredictionCheckpoints = %v, want %v", got, expected)
+	} else {
+		for i := range expected {
+			if got[i] != expected[i] {
+				t.Fatalf("PredictionCheckpoints = %v, want %v", got, expected)
+			}
+		}
+	}
+}
+
+func TestOptionsFromEnvDoesNotDefaultInvalidExplicitCheckpoints(t *testing.T) {
+	t.Setenv("PREDICTIVE_PROVIDER_ENABLED", "true")
+	t.Setenv(providerEnv("URL"), "http://127.0.0.1:8081")
+	t.Setenv("PREDICTIVE_RELIABILITY_CHECKPOINTS", "bad,0")
+
+	options := OptionsFromEnv()
+
+	if got := options.PredictionCheckpoints; len(got) != 0 {
+		t.Fatalf("PredictionCheckpoints = %v, want empty for invalid explicit config", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Predictive reliability now has a stable public default checkpoint schedule when a production provider is enabled and no explicit checkpoint list is configured. Public builds still stay disabled by default, and explicit `PREDICTIVE_RELIABILITY_CHECKPOINTS` values continue to override the fallback.

The public contract remains limited to advisory checkpoint records. The docs mention only the checkpoint override and default windows, while the leakage guard continues to block provider release details from public docs and tests.

## Validation

- `npm test -- --runInBand`
- `cd backend && bazel test //...`
- Live predictive remote smoke passed in `cdsap/experiment-agp-9.2.1`: https://github.com/cdsap/experiment-agp-9.2.1/actions/runs/31141419023
- Verified backend run record `bpw-31141419023-1`: `finished=true`, 366 samples, and ready prediction checkpoints at 30s, 60s, and 180s.
- Verified artifact `build_process_watcher-gradle-build-1` uploaded with JSON, CSV, watcher log, and memory/GC/JIT/class-loading SVGs.

Related: #119
