### PR TITLE
fix: align deploy smoke with default checkpoints

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -108,7 +108,15 @@ jobs:
           --data @/tmp/ingest-request.json \
           | jq -e '.status == "success"'
 
-        EXPECTED_CHECKPOINTS="$(printf '%s' "$PREDICTIVE_RELIABILITY_CHECKPOINTS" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | length')"
+        CHECKPOINT_WINDOWS="${PREDICTIVE_RELIABILITY_CHECKPOINTS:-60,300,600,1200}"
+        EXPECTED_CHECKPOINTS="$(printf '%s' "$CHECKPOINT_WINDOWS" | jq -R '
+          split(",")
+          | map(gsub("^\\s+|\\s+$"; ""))
+          | map(select(length > 0))
+          | map(tonumber? // empty)
+          | map(select(. <= 180))
+          | length
+        ')"
         for attempt in $(seq 1 12); do
           curl --fail --silent --show-error "$SERVICE_URL/runs/$RUN_ID" > /tmp/smoke-run.json
           if jq -e --argjson expected "$EXPECTED_CHECKPOINTS" '


### PR DESCRIPTION
## Summary

The backend deploy smoke now matches the checkpoint behavior that landed in #127. When `PREDICTIVE_RELIABILITY_CHECKPOINTS` is empty, the smoke uses the backend default windows `60,300,600,1200` instead of expecting zero checkpoints.

The smoke also counts only checkpoint windows reached by its synthetic 180s telemetry. This keeps explicit windows such as `30,60,180` expecting three checkpoints, while the default schedule expects one reached checkpoint at 60s.

## Validation

- Ruby YAML parse for `.github/workflows/deploy-backend.yml`
- JQ expression check: default `60,300,600,1200` expects `1`
- JQ expression check: explicit `30,60,180` expects `3`
- `git diff --check`

Related: #127
