### PR TITLE
fix: predictive reliability: review public contract needs for relative-p

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ This is not required for normal local or remote monitoring. Use it only when you
 
 When run data contains public-safe `prediction_checkpoints`, the dashboard renders those checkpoint records in observation-window order. The public contract intentionally omits non-public implementation details, exact checkpoint policy, training data, and service endpoints.
 
+**Relative-progress checkpoints (v2):** No public schema or dashboard change is required. Private providers may schedule evaluations by relative progress, but public run JSON continues to use the existing `prediction_checkpoints` fields keyed by `observation_window_s` (elapsed seconds at evaluation). Optional public-safe labels, if ever needed, can use existing `signals` or `message` without new required fields. Legacy runs that omit `prediction_checkpoints` remain valid.
+
 `PREDICTIVE_RELIABILITY_CHECKPOINTS` can set a comma-separated checkpoint window list. When a production provider is enabled and this value is empty, the backend uses `60,300,600,1200`.
 
 The public backend sends only public run telemetry to `/predict` and stores only the returned public-safe checkpoint. Do not add private model names, thresholds, feature formulas, training data paths, or customer-specific tuning to this repository or to public frontend config.

--- a/__tests__/predictive-reliability-boundary.test.ts
+++ b/__tests__/predictive-reliability-boundary.test.ts
@@ -106,4 +106,17 @@ describe('predictive reliability public boundary', () => {
 
     expect(violations).toEqual([]);
   });
+
+  it('documents that relative-progress checkpoints need no public schema change', () => {
+    const readme = readRepoFile('README.md');
+    expect(readme).toContain('Relative-progress checkpoints (v2)');
+    expect(readme).toContain('No public schema or dashboard change is required');
+    expect(readme).toContain('observation_window_s');
+    expect(readme).toContain('Legacy runs that omit `prediction_checkpoints` remain valid');
+
+    const models = readRepoFile('backend/internal/models/models.go');
+    expect(models).toContain('No additional public fields are required for relative-progress results');
+    expect(models).not.toMatch(/\brelative_progress\b/);
+    expect(models).not.toMatch(/\bprogress_(ratio|pct|percent)\b/);
+  });
 });

--- a/__tests__/run-dashboard-responsive.test.ts
+++ b/__tests__/run-dashboard-responsive.test.ts
@@ -35,4 +35,33 @@ describe('run dashboard responsive layout', () => {
     expect(evaluatePredicate(false, 1)).toBe(true);
     expect(evaluatePredicate(false, 0)).toBe(false);
   });
+
+  it('accepts relative-progress results on existing checkpoint fields without new schema keys', () => {
+    expect(source).toContain(
+      '[...data.prediction_checkpoints].sort((a, b) => Number(a.observation_window_s || 0) - Number(b.observation_window_s || 0))',
+    );
+    expect(source).not.toContain('relative_progress');
+    expect(source).not.toContain('progress_ratio');
+    expect(source).not.toContain('progress_pct');
+
+    const sortCheckpoints = (data: { prediction_checkpoints?: Array<Record<string, unknown>> }) => (
+      Array.isArray(data.prediction_checkpoints)
+        ? [...data.prediction_checkpoints].sort(
+          (a, b) => Number(a.observation_window_s || 0) - Number(b.observation_window_s || 0),
+        )
+        : []
+    );
+
+    expect(sortCheckpoints({})).toEqual([]);
+    expect(sortCheckpoints({ prediction_checkpoints: undefined })).toEqual([]);
+
+    const sorted = sortCheckpoints({
+      prediction_checkpoints: [
+        { observation_window_s: 247, status: 'ready', risk_level: 'low' },
+        { observation_window_s: 91, status: 'ready', risk_level: 'elevated' },
+      ],
+    });
+    expect(sorted.map(checkpoint => checkpoint.observation_window_s)).toEqual([91, 247]);
+    expect(sorted.every(checkpoint => !('relative_progress' in checkpoint))).toBe(true);
+  });
 });

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -58,6 +58,9 @@ type RunDoc struct {
 }
 
 // PredictionCheckpoint is a public-safe prediction result for one observation window.
+// Relative-progress scheduling is private provider policy; when such a gate fires,
+// results still use this shape with observation_window_s set to elapsed seconds at
+// evaluation. No additional public fields are required for relative-progress results.
 type PredictionCheckpoint struct {
 	ObservationWindowS int       `json:"observation_window_s" firestore:"observation_window_s"`
 	Status             string    `json:"status" firestore:"status"`

--- a/backend/internal/models/models_test.go
+++ b/backend/internal/models/models_test.go
@@ -219,6 +219,90 @@ func TestRunResponse_OmitsPredictionCheckpointsWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestRunResponse_AcceptsLegacyJSONWithoutPredictionFields(t *testing.T) {
+	payload := []byte(`{"samples":[],"finished":true,"updated_at":"2026-01-01T00:00:00Z"}`)
+	var response RunResponse
+	if err := json.Unmarshal(payload, &response); err != nil {
+		t.Fatalf("legacy run JSON should unmarshal without prediction fields: %v", err)
+	}
+	if response.PredictionCheckpoints != nil {
+		t.Fatalf("PredictionCheckpoints = %v, want nil for legacy runs", response.PredictionCheckpoints)
+	}
+}
+
+func TestRunResponse_RelativeProgressResultsUseExistingCheckpointFields(t *testing.T) {
+	// Relative-progress gates remain private; public results still key by elapsed seconds.
+	riskScore := 18.0
+	peakRSS := 1536.0
+	duration := 420.0
+	createdAt := time.Unix(456, 0).UTC()
+	response := RunResponse{
+		Samples: []Sample{},
+		PredictionCheckpoints: []PredictionCheckpoint{
+			{
+				ObservationWindowS: 247,
+				Status:             "ready",
+				RiskLevel:          "low",
+				RiskScore:          &riskScore,
+				Confidence:         "medium",
+				PredictedPeakRSSMB: &peakRSS,
+				PredictedDurationS: &duration,
+				Signals:            []string{"stable memory trend"},
+				ProviderID:         "private",
+				ModelVersion:       "opaque-v2",
+				CreatedAt:          createdAt,
+				Message:            "checkpoint ready",
+			},
+		},
+		Finished: false,
+	}
+
+	jsonData, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("Failed to marshal RunResponse: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(jsonData, &raw); err != nil {
+		t.Fatalf("Failed to unmarshal RunResponse map: %v", err)
+	}
+	checkpoints, ok := raw["prediction_checkpoints"].([]any)
+	if !ok || len(checkpoints) != 1 {
+		t.Fatalf("prediction_checkpoints = %v, want one checkpoint", raw["prediction_checkpoints"])
+	}
+	checkpoint, ok := checkpoints[0].(map[string]any)
+	if !ok {
+		t.Fatalf("checkpoint entry type = %T, want object", checkpoints[0])
+	}
+	for _, disallowed := range []string{
+		"relative_progress",
+		"progress_ratio",
+		"progress_pct",
+		"progress_percent",
+		"checkpoint_policy",
+		"evaluation_threshold",
+	} {
+		if _, present := checkpoint[disallowed]; present {
+			t.Fatalf("public checkpoint must not require %q: %s", disallowed, jsonData)
+		}
+	}
+
+	var unmarshaled RunResponse
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal RunResponse: %v", err)
+	}
+	if len(unmarshaled.PredictionCheckpoints) != 1 {
+		t.Fatalf("PredictionCheckpoints length = %d, want 1", len(unmarshaled.PredictionCheckpoints))
+	}
+	got := unmarshaled.PredictionCheckpoints[0]
+	if got.ObservationWindowS != 247 {
+		t.Fatalf("ObservationWindowS = %d, want 247", got.ObservationWindowS)
+	}
+	if got.Status != "ready" || got.RiskLevel != "low" || got.Confidence != "medium" {
+		t.Fatalf("unexpected checkpoint fields: %+v", got)
+	}
+}
+
 func TestRunDoc_PredictiveReliabilityDefaultsFalse(t *testing.T) {
 	var runDoc RunDoc
 	payload := []byte(`{"run_id":"run-1"}`)


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/build-process-watcher#130: Predictive reliability: review public contract needs for relative-progress checkpoints

Fixes #130

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `medium`

## Verification

- `npm test -- --runInBand`