### PR TITLE
fix: refactor monitoring mode resolution to isolate policy

### DIFF
--- a/__tests__/index-with-backend-flags.test.ts
+++ b/__tests__/index-with-backend-flags.test.ts
@@ -1,4 +1,8 @@
-import { resolveMonitoringFeatureFlags } from '../src/monitoring_features';
+import {
+  DEFAULT_BACKEND_URL,
+  DEFAULT_FRONTEND_BASE_URL,
+  resolveMonitoringFeatureFlags,
+} from '../src/monitoring_features';
 
 describe('resolveMonitoringFeatureFlags', () => {
   it('keeps local mode when no remote-only feature is requested', () => {
@@ -7,8 +11,27 @@ describe('resolveMonitoringFeatureFlags', () => {
       exportToBigqueryRequested: false,
       predictiveReliabilityRequested: false,
       backendUrl: '',
+      runId: 'run-1',
     })).toEqual({
       enableBackend: false,
+      backendUrl: '',
+      frontendUrl: '',
+      exportToBigquery: false,
+      predictiveReliability: false,
+    });
+  });
+
+  it('preserves an unused backend URL when remote features are off', () => {
+    expect(resolveMonitoringFeatureFlags({
+      remoteMonitoringRequested: false,
+      exportToBigqueryRequested: false,
+      predictiveReliabilityRequested: false,
+      backendUrl: 'https://backend.example',
+      runId: 'run-1',
+    })).toEqual({
+      enableBackend: false,
+      backendUrl: 'https://backend.example',
+      frontendUrl: '',
       exportToBigquery: false,
       predictiveReliability: false,
     });
@@ -20,8 +43,11 @@ describe('resolveMonitoringFeatureFlags', () => {
       exportToBigqueryRequested: true,
       predictiveReliabilityRequested: false,
       backendUrl: 'https://backend.example',
+      runId: 'run-1',
     })).toEqual({
       enableBackend: false,
+      backendUrl: 'https://backend.example',
+      frontendUrl: '',
       exportToBigquery: false,
       predictiveReliability: false,
     });
@@ -33,10 +59,95 @@ describe('resolveMonitoringFeatureFlags', () => {
       exportToBigqueryRequested: false,
       predictiveReliabilityRequested: true,
       backendUrl: 'https://backend.example',
+      runId: 'run-1',
     })).toEqual({
       enableBackend: true,
+      backendUrl: 'https://backend.example',
+      frontendUrl: `${DEFAULT_FRONTEND_BASE_URL}/runs/run-1`,
       exportToBigquery: true,
       predictiveReliability: true,
+    });
+  });
+
+  it('injects the default backend URL for remote monitoring when none is provided', () => {
+    expect(resolveMonitoringFeatureFlags({
+      remoteMonitoringRequested: true,
+      exportToBigqueryRequested: false,
+      predictiveReliabilityRequested: false,
+      backendUrl: '',
+      runId: 'run-remote',
+    })).toEqual({
+      enableBackend: true,
+      backendUrl: DEFAULT_BACKEND_URL,
+      frontendUrl: `${DEFAULT_FRONTEND_BASE_URL}/runs/run-remote`,
+      exportToBigquery: false,
+      predictiveReliability: false,
+    });
+  });
+
+  it('injects the default backend URL for predictive reliability when none is provided', () => {
+    expect(resolveMonitoringFeatureFlags({
+      remoteMonitoringRequested: false,
+      exportToBigqueryRequested: false,
+      predictiveReliabilityRequested: true,
+      runId: 'run-predictive',
+    })).toEqual({
+      enableBackend: true,
+      backendUrl: DEFAULT_BACKEND_URL,
+      frontendUrl: `${DEFAULT_FRONTEND_BASE_URL}/runs/run-predictive`,
+      exportToBigquery: true,
+      predictiveReliability: true,
+    });
+  });
+
+  it('builds a frontend run URL when the base already ends with /runs', () => {
+    expect(resolveMonitoringFeatureFlags({
+      remoteMonitoringRequested: true,
+      exportToBigqueryRequested: false,
+      predictiveReliabilityRequested: false,
+      backendUrl: 'https://backend.example',
+      frontendUrl: 'https://frontend.example/runs',
+      runId: 'run-abc',
+    })).toEqual({
+      enableBackend: true,
+      backendUrl: 'https://backend.example',
+      frontendUrl: 'https://frontend.example/runs/run-abc',
+      exportToBigquery: false,
+      predictiveReliability: false,
+    });
+  });
+
+  it('builds a frontend run URL when the base already ends with /runs/', () => {
+    expect(resolveMonitoringFeatureFlags({
+      remoteMonitoringRequested: true,
+      exportToBigqueryRequested: false,
+      predictiveReliabilityRequested: false,
+      backendUrl: 'https://backend.example',
+      frontendUrl: 'https://frontend.example/runs/',
+      runId: 'run-abc',
+    })).toEqual({
+      enableBackend: true,
+      backendUrl: 'https://backend.example',
+      frontendUrl: 'https://frontend.example/runs//run-abc',
+      exportToBigquery: false,
+      predictiveReliability: false,
+    });
+  });
+
+  it('appends /runs/:runId when the frontend base does not end with /runs', () => {
+    expect(resolveMonitoringFeatureFlags({
+      remoteMonitoringRequested: true,
+      exportToBigqueryRequested: false,
+      predictiveReliabilityRequested: false,
+      backendUrl: 'https://backend.example',
+      frontendUrl: 'https://frontend.example',
+      runId: 'run-abc',
+    })).toEqual({
+      enableBackend: true,
+      backendUrl: 'https://backend.example',
+      frontendUrl: 'https://frontend.example/runs/run-abc',
+      exportToBigquery: false,
+      predictiveReliability: false,
     });
   });
 });

--- a/src/index_with_backend.ts
+++ b/src/index_with_backend.ts
@@ -8,7 +8,8 @@ import { resolveMonitoringFeatureFlags } from './monitoring_features';
 
 async function run() {
   try {
-    let backendUrl = process.env.BACKEND_URL || '';
+    const requestedBackendUrl = process.env.BACKEND_URL || '';
+    const requestedFrontendUrl = process.env.FRONTEND_URL || '';
     const remoteMonitoringRequested = core.getInput('remote_monitoring') === 'true';
     const runId = core.getInput('run_id') || `run-${Date.now()}`;
     const debugMode = core.getInput('debug') === 'true';
@@ -35,28 +36,25 @@ async function run() {
     const exportToBigqueryRequested = core.getInput('export_to_bigquery') === 'true';
     const predictiveReliabilityRequested = core.getInput('predictive_reliability') === 'true';
 
-    const enableBackendRequested = remoteMonitoringRequested || predictiveReliabilityRequested;
-
-    // If backend is enabled but no URL provided, use the default Cloud Run URL
-    if (enableBackendRequested && !backendUrl) {
-      // Default production backend URL
-      backendUrl = 'https://build-process-watcher-backend-685615422311.us-central1.run.app';
-      if (debugMode) {
-        core.info(`🔧 Backend enabled but no URL provided, using default URL: ${backendUrl}`);
-      }
-    }
-
     const {
       enableBackend,
+      backendUrl,
+      frontendUrl,
       exportToBigquery,
       predictiveReliability,
     } = resolveMonitoringFeatureFlags({
       remoteMonitoringRequested,
       exportToBigqueryRequested,
       predictiveReliabilityRequested,
-      backendUrl,
+      backendUrl: requestedBackendUrl,
+      frontendUrl: requestedFrontendUrl,
+      runId,
     });
     const useBackend = enableBackend && !!backendUrl;
+
+    if (enableBackend && !requestedBackendUrl && debugMode) {
+      core.info(`🔧 Backend enabled but no URL provided, using default URL: ${backendUrl}`);
+    }
 
     if (predictiveReliabilityRequested && debugMode) {
       core.info(`🔮 predictive_reliability enables remote_monitoring and export_to_bigquery for this run`);
@@ -73,28 +71,7 @@ async function run() {
       core.info(`🌐 Backend URL: ${backendUrl || 'Not provided'}`);
       core.info(`⚙️  Remote Monitoring: ${enableBackend}`);
       core.info(`🐛 Debug Mode: ${debugMode}`);
-    }
-
-    // Build frontend URL if backend is enabled (do this before exporting)
-    let frontendUrl = '';
-    if (enableBackend && backendUrl) {
-      // Use FRONTEND_URL env var (from secrets) or default
-      const explicitFrontendUrl = process.env.FRONTEND_URL || '';
-      
-      if (explicitFrontendUrl) {
-        // Use explicitly provided frontend URL (from env var or input)
-        if (explicitFrontendUrl.endsWith('/runs') || explicitFrontendUrl.endsWith('/runs/')) {
-          frontendUrl = `${explicitFrontendUrl}/${runId}`;
-        } else {
-          frontendUrl = `${explicitFrontendUrl}/runs/${runId}`;
-        }
-        
-      } else {
-        const baseFrontendUrl = 'https://process-watcher.web.app';
-        frontendUrl = `${baseFrontendUrl}/runs/${runId}`;
-      }
-      
-      if (debugMode) {
+      if (frontendUrl) {
         core.info(`🌐 Frontend URL: ${frontendUrl}`);
       }
     }

--- a/src/monitoring_features.ts
+++ b/src/monitoring_features.ts
@@ -1,21 +1,56 @@
+export const DEFAULT_BACKEND_URL =
+  'https://build-process-watcher-backend-685615422311.us-central1.run.app';
+export const DEFAULT_FRONTEND_BASE_URL = 'https://process-watcher.web.app';
+
 export interface MonitoringFeatureFlags {
   enableBackend: boolean;
+  backendUrl: string;
+  frontendUrl: string;
   exportToBigquery: boolean;
   predictiveReliability: boolean;
+}
+
+function buildFrontendRunUrl(frontendBaseUrl: string, runId: string): string {
+  if (frontendBaseUrl.endsWith('/runs') || frontendBaseUrl.endsWith('/runs/')) {
+    return `${frontendBaseUrl}/${runId}`;
+  }
+  return `${frontendBaseUrl}/runs/${runId}`;
 }
 
 export function resolveMonitoringFeatureFlags(inputs: {
   remoteMonitoringRequested: boolean;
   exportToBigqueryRequested: boolean;
   predictiveReliabilityRequested: boolean;
-  backendUrl: string;
+  backendUrl?: string;
+  frontendUrl?: string;
+  runId: string;
 }): MonitoringFeatureFlags {
-  const enableBackend = inputs.remoteMonitoringRequested || inputs.predictiveReliabilityRequested;
-  const useBackend = enableBackend && !!inputs.backendUrl;
+  const enableBackend =
+    inputs.remoteMonitoringRequested || inputs.predictiveReliabilityRequested;
+
+  let backendUrl = inputs.backendUrl || '';
+  if (enableBackend && !backendUrl) {
+    backendUrl = DEFAULT_BACKEND_URL;
+  }
+
+  const useBackend = enableBackend && !!backendUrl;
+
+  let frontendUrl = '';
+  if (useBackend) {
+    const explicitFrontendUrl = inputs.frontendUrl || '';
+    if (explicitFrontendUrl) {
+      frontendUrl = buildFrontendRunUrl(explicitFrontendUrl, inputs.runId);
+    } else {
+      frontendUrl = buildFrontendRunUrl(DEFAULT_FRONTEND_BASE_URL, inputs.runId);
+    }
+  }
 
   return {
     enableBackend,
-    exportToBigquery: (inputs.exportToBigqueryRequested || inputs.predictiveReliabilityRequested) && useBackend,
+    backendUrl,
+    frontendUrl,
+    exportToBigquery:
+      (inputs.exportToBigqueryRequested || inputs.predictiveReliabilityRequested) && useBackend,
     predictiveReliability: inputs.predictiveReliabilityRequested && useBackend,
   };
 }


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/build-process-watcher#132: Refactor monitoring mode resolution to isolate policy

Fixes #132

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `npm test -- --runInBand`