### PR TITLE
fix: retry non-ready predictive checkpoints

### DIFF
--- a/backend/pkg/predictor/predictor.go
+++ b/backend/pkg/predictor/predictor.go
@@ -66,7 +66,7 @@ func DefaultCheckpoints() []int {
 	return checkpoints
 }
 
-// PendingCheckpoints returns configured windows reached by samples and not yet stored.
+// PendingCheckpoints returns configured windows reached by samples and not yet ready.
 func PendingCheckpoints(samples []Sample, existing []PredictionCheckpoint, configured []int) []int {
 	if len(samples) == 0 || len(configured) == 0 {
 		return nil
@@ -79,9 +79,11 @@ func PendingCheckpoints(samples []Sample, existing []PredictionCheckpoint, confi
 		}
 	}
 
-	stored := make(map[int]bool, len(existing))
+	ready := make(map[int]bool, len(existing))
 	for _, checkpoint := range existing {
-		stored[checkpoint.ObservationWindowS] = true
+		if checkpoint.Status == "ready" {
+			ready[checkpoint.ObservationWindowS] = true
+		}
 	}
 
 	seen := make(map[int]bool, len(configured))
@@ -91,7 +93,7 @@ func PendingCheckpoints(samples []Sample, existing []PredictionCheckpoint, confi
 			continue
 		}
 		seen[checkpoint] = true
-		if maxElapsed >= checkpoint && !stored[checkpoint] {
+		if maxElapsed >= checkpoint && !ready[checkpoint] {
 			pending = append(pending, checkpoint)
 		}
 	}

--- a/backend/pkg/predictor/predictor_test.go
+++ b/backend/pkg/predictor/predictor_test.go
@@ -72,7 +72,7 @@ func TestDefaultCheckpoints(t *testing.T) {
 func TestPendingCheckpointsReturnsReachedMissingWindows(t *testing.T) {
 	pending := PendingCheckpoints(
 		[]Sample{{ElapsedTime: 10}, {ElapsedTime: 75}},
-		[]PredictionCheckpoint{{ObservationWindowS: 30}},
+		[]PredictionCheckpoint{{ObservationWindowS: 30, Status: "ready"}},
 		[]int{60, 30, 180, 60},
 	)
 
@@ -81,18 +81,19 @@ func TestPendingCheckpointsReturnsReachedMissingWindows(t *testing.T) {
 	}
 }
 
-func TestPendingCheckpointsTreatsAnyStoredStatusAsComplete(t *testing.T) {
+func TestPendingCheckpointsRetriesNonReadyStatuses(t *testing.T) {
 	pending := PendingCheckpoints(
 		[]Sample{{ElapsedTime: 180}},
 		[]PredictionCheckpoint{
 			{ObservationWindowS: 30, Status: "error"},
 			{ObservationWindowS: 60, Status: "skipped"},
+			{ObservationWindowS: 180, Status: "ready"},
 		},
 		[]int{30, 60, 180},
 	)
 
-	if len(pending) != 1 || pending[0] != 180 {
-		t.Fatalf("pending = %v, want [180]", pending)
+	if len(pending) != 2 || pending[0] != 30 || pending[1] != 60 {
+		t.Fatalf("pending = %v, want [30 60]", pending)
 	}
 }
 


### PR DESCRIPTION
## Summary
- retry predictive checkpoints that previously stored non-ready statuses such as skipped or error
- keep ready checkpoints as complete so successful windows are not re-evaluated
- update predictor tests to cover the retry behavior observed in the external smoke path

## Validation
- cd backend && bazel test //...