### PR TITLE
fix: carry predictive checkpoints through ingest

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -275,7 +275,9 @@ func (h *Handlers) evaluatePredictionCheckpoints(ctx context.Context, runID stri
 		}
 		if err := h.storage.StorePredictionCheckpoint(runID, checkpoint); err != nil {
 			log.Printf("Prediction checkpoint store failed for run %s checkpoint %ds: %v", runID, checkpointWindow, err)
+			continue
 		}
+		runDoc.PredictionCheckpoints = storage.MergePredictionCheckpoint(runDoc.PredictionCheckpoints, checkpoint)
 	}
 }
 


### PR DESCRIPTION
## Summary
- carry stored prediction checkpoints forward during a single ingest evaluation loop
- lets later checkpoint calls see earlier ready checkpoints from the same ingest request
- keeps failed store attempts out of the in-memory checkpoint list

## Why
The public backend deploy smoke on run 31890580095 deployed successfully but failed predictive verification with:

samples=3, expected_checkpoints=3, checkpoints=3, statuses=skipped,ready,skipped

The previous retry fix handles non-ready checkpoints across later ingests. This follow-up handles the single-ingest path used by the deploy smoke and external contract path.

## Validation
- cd backend && bazel test //...