### PR TITLE
fix: refactor scoring fallback errors to shared failure taxonomy

### DIFF
--- a/backend/internal/handlers/BUILD.bazel
+++ b/backend/internal/handlers/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//internal/auth",
         "//internal/exportqueue",
         "//internal/models",
+        "//internal/scoring",
         "//internal/storage",
         "//pkg/predictor",
     ],
@@ -18,5 +19,8 @@ go_test(
     name = "handlers_test",
     srcs = ["handlers_test.go"],
     embed = [":handlers"],
-    deps = ["//internal/models"],
+    deps = [
+        "//internal/models",
+        "//internal/scoring",
+    ],
 )

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/cdsap/build-process-watcher/backend/internal/auth"
 	"github.com/cdsap/build-process-watcher/backend/internal/exportqueue"
 	"github.com/cdsap/build-process-watcher/backend/internal/models"
+	"github.com/cdsap/build-process-watcher/backend/internal/scoring"
 	"github.com/cdsap/build-process-watcher/backend/internal/storage"
 	"github.com/cdsap/build-process-watcher/backend/pkg/predictor"
 )
@@ -259,11 +261,12 @@ func (h *Handlers) evaluatePredictionCheckpoints(ctx context.Context, runID stri
 			Now:                   time.Now(),
 		}, checkpointWindow)
 		if err != nil {
+			fallbackStatus, fallbackMessage := classifyPredictionFallback(err)
 			checkpoint = models.PredictionCheckpoint{
 				ObservationWindowS: checkpointWindow,
-				Status:             "error",
+				Status:             fallbackStatus,
 				CreatedAt:          time.Now(),
-				Message:            "prediction provider error",
+				Message:            fallbackMessage,
 			}
 			log.Printf("Prediction provider failed for run %s checkpoint %ds: %v", runID, checkpointWindow, err)
 		}
@@ -278,6 +281,21 @@ func (h *Handlers) evaluatePredictionCheckpoints(ctx context.Context, runID stri
 			continue
 		}
 		runDoc.PredictionCheckpoints = storage.MergePredictionCheckpoint(runDoc.PredictionCheckpoints, checkpoint)
+	}
+}
+
+// classifyPredictionFallback maps provider failures onto the shared scoring
+// taxonomy without importing a concrete provider implementation.
+func classifyPredictionFallback(err error) (status string, message string) {
+	switch {
+	case errors.Is(err, scoring.ErrNoData):
+		return "no_data", "prediction data unavailable"
+	case errors.Is(err, scoring.ErrModelUnavailable):
+		return "model_unavailable", "prediction model unavailable"
+	case errors.Is(err, scoring.ErrScoringTimeout), errors.Is(err, scoring.ErrScoringFailed):
+		return "provider_error", "prediction provider error"
+	default:
+		return "provider_error", "prediction provider error"
 	}
 }
 

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -2,11 +2,13 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/cdsap/build-process-watcher/backend/internal/models"
+	"github.com/cdsap/build-process-watcher/backend/internal/scoring"
 )
 
 func TestIngestHandler_RequestWithProcessInfo(t *testing.T) {
@@ -59,6 +61,58 @@ func TestBoolQueryAcceptsExplicitTrueOnly(t *testing.T) {
 	request = httptest.NewRequest("POST", "/auth/run/run-1?predictive_reliability=maybe", nil)
 	if boolQuery(request, "predictive_reliability") {
 		t.Fatal("expected invalid predictive_reliability value to be rejected")
+	}
+}
+
+func TestClassifyPredictionFallbackUsesSharedScoringTaxonomy(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantStatus  string
+		wantMessage string
+	}{
+		{
+			name:        "no data",
+			err:         fmt.Errorf("provider context: %w", scoring.ErrNoData),
+			wantStatus:  "no_data",
+			wantMessage: "prediction data unavailable",
+		},
+		{
+			name:        "model unavailable",
+			err:         fmt.Errorf("provider context: %w", scoring.ErrModelUnavailable),
+			wantStatus:  "model_unavailable",
+			wantMessage: "prediction model unavailable",
+		},
+		{
+			name:        "scoring failed",
+			err:         fmt.Errorf("provider context: %w", scoring.ErrScoringFailed),
+			wantStatus:  "provider_error",
+			wantMessage: "prediction provider error",
+		},
+		{
+			name:        "scoring timeout",
+			err:         fmt.Errorf("provider context: %w", scoring.ErrScoringTimeout),
+			wantStatus:  "provider_error",
+			wantMessage: "prediction provider error",
+		},
+		{
+			name:        "unknown error",
+			err:         fmt.Errorf("unexpected provider failure"),
+			wantStatus:  "provider_error",
+			wantMessage: "prediction provider error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStatus, gotMessage := classifyPredictionFallback(tt.err)
+			if gotStatus != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", gotStatus, tt.wantStatus)
+			}
+			if gotMessage != tt.wantMessage {
+				t.Fatalf("message = %q, want %q", gotMessage, tt.wantMessage)
+			}
+		})
 	}
 }
 

--- a/backend/internal/scoring/BUILD.bazel
+++ b/backend/internal/scoring/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "scoring",
+    srcs = ["errors.go"],
+    importpath = "github.com/cdsap/build-process-watcher/backend/internal/scoring",
+    visibility = ["//:__subpackages__"],
+)

--- a/backend/internal/scoring/errors.go
+++ b/backend/internal/scoring/errors.go
@@ -1,0 +1,10 @@
+package scoring
+
+import "errors"
+
+var (
+	ErrNoData           = errors.New("prediction scoring no data")
+	ErrScoringTimeout   = errors.New("prediction scoring timeout")
+	ErrScoringFailed    = errors.New("prediction scoring failed")
+	ErrModelUnavailable = errors.New("prediction model unavailable")
+)

--- a/backend/pkg/predictor/BUILD.bazel
+++ b/backend/pkg/predictor/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/models",
+        "//internal/scoring",
         "@org_golang_google_api//idtoken",
     ],
 )

--- a/backend/pkg/predictor/remote.go
+++ b/backend/pkg/predictor/remote.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/cdsap/build-process-watcher/backend/internal/scoring"
 	"google.golang.org/api/idtoken"
 )
 
@@ -81,22 +84,68 @@ func (p *RemoteProvider) Predict(ctx context.Context, snapshot RunSnapshot, obse
 
 	resp, err := p.client.Do(req)
 	if err != nil {
-		return PredictionCheckpoint{}, fmt.Errorf("remote prediction request failed: %w", err)
+		kind := scoring.ErrScoringFailed
+		if isTimeoutError(err) {
+			kind = scoring.ErrScoringTimeout
+		}
+		return PredictionCheckpoint{}, newScoringError(kind, fmt.Sprintf("remote prediction request failed: %v", err), err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return PredictionCheckpoint{}, fmt.Errorf("remote prediction provider returned status %d", resp.StatusCode)
+		return PredictionCheckpoint{}, newScoringError(classifyRemoteStatus(resp.StatusCode), fmt.Sprintf("remote prediction provider returned status %d", resp.StatusCode), nil)
 	}
 
 	decoder := json.NewDecoder(resp.Body)
 	var response remotePredictResponse
 	if err := decoder.Decode(&response); err != nil {
-		return PredictionCheckpoint{}, fmt.Errorf("decode prediction response: %w", err)
+		return PredictionCheckpoint{}, newScoringError(scoring.ErrScoringFailed, fmt.Sprintf("decode prediction response: %v", err), err)
 	}
 	if response.Checkpoint.ObservationWindowS == 0 {
 		response.Checkpoint.ObservationWindowS = observationWindowS
 	}
 	return response.Checkpoint, nil
+}
+
+type scoringError struct {
+	kind    error
+	message string
+	cause   error
+}
+
+func newScoringError(kind error, message string, cause error) error {
+	return scoringError{kind: kind, message: message, cause: cause}
+}
+
+func (e scoringError) Error() string {
+	return e.message
+}
+
+func (e scoringError) Unwrap() []error {
+	if e.cause == nil {
+		return []error{e.kind}
+	}
+	return []error{e.kind, e.cause}
+}
+
+func classifyRemoteStatus(statusCode int) error {
+	switch statusCode {
+	case http.StatusNotFound:
+		return scoring.ErrNoData
+	case http.StatusRequestTimeout, http.StatusGatewayTimeout:
+		return scoring.ErrScoringTimeout
+	case http.StatusServiceUnavailable:
+		return scoring.ErrModelUnavailable
+	default:
+		return scoring.ErrScoringFailed
+	}
+}
+
+func isTimeoutError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 type remotePredictRequest struct {

--- a/backend/pkg/predictor/remote_test.go
+++ b/backend/pkg/predictor/remote_test.go
@@ -3,11 +3,14 @@ package predictor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/cdsap/build-process-watcher/backend/internal/scoring"
 )
 
 func TestRemoteProviderPostsPublicPredictionRequest(t *testing.T) {
@@ -87,6 +90,43 @@ func TestRemoteProviderReturnsStatusError(t *testing.T) {
 	_, err = provider.Predict(context.Background(), RunSnapshot{}, 30)
 	if err == nil || !strings.Contains(err.Error(), "status 418") {
 		t.Fatalf("error = %v, want status 418", err)
+	}
+	if !errors.Is(err, scoring.ErrScoringFailed) {
+		t.Fatalf("error = %v, want scoring failed sentinel", err)
+	}
+}
+
+func TestRemoteProviderClassifiesSharedScoringErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		want       error
+	}{
+		{name: "no data", statusCode: http.StatusNotFound, want: scoring.ErrNoData},
+		{name: "timeout", statusCode: http.StatusGatewayTimeout, want: scoring.ErrScoringTimeout},
+		{name: "model unavailable", statusCode: http.StatusServiceUnavailable, want: scoring.ErrModelUnavailable},
+		{name: "provider error", statusCode: http.StatusInternalServerError, want: scoring.ErrScoringFailed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "nope", tt.statusCode)
+			}))
+			defer remote.Close()
+
+			provider, err := NewRemoteProvider(RemoteConfig{URL: remote.URL})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = provider.Predict(context.Background(), RunSnapshot{}, 30)
+			if err == nil {
+				t.Fatal("expected non-2xx status to return error")
+			}
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("error = %v, want sentinel %v", err, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/build-process-watcher#136: Refactor scoring fallback errors to shared failure taxonomy

Fixes #136

## Agent routing

- Selected agent: `cursor`
- Routing reason: `sufficient_codex_capacity`
- Complexity: `large`

## Verification

- `npm test -- --runInBand`