### PR TITLE
fix: add predictions tab to run dashboard

### DIFF
--- a/__tests__/demo-dashboard.test.ts
+++ b/__tests__/demo-dashboard.test.ts
@@ -14,7 +14,8 @@ describe('demo dashboard', () => {
     expect(html).toContain('Class Loading Activity');
     expect(html).toContain('window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true || predictionCheckpoints.length > 0');
     expect(html).toContain('prediction_checkpoints');
-    expect(html).toContain('predictionHtml');
+    expect(html).toContain('predictionTabHtml');
+    expect(html).toContain('data-run-tab="predictions"');
     expect(html).not.toContain('/runs/${runId}');
 
     const data = JSON.parse(fs.readFileSync(demoData, 'utf8'));

--- a/__tests__/run-dashboard-predictions.test.ts
+++ b/__tests__/run-dashboard-predictions.test.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const runDashboardPath = path.join(__dirname, '../frontend/public/runs/[runId].html');
+const demoDashboardPath = path.join(__dirname, '../frontend/public/runs/demo.html');
+const demoDataPath = path.join(__dirname, '../frontend/public/demo-run.json');
+
+function extractPredictionHelpers(source: string) {
+  const sortMatch = source.match(
+    /const predictionCheckpoints = Array\.isArray\(data\.prediction_checkpoints\)\s*\n\s*\? \[\.\.\.data\.prediction_checkpoints\]\.sort\(\(a, b\) => Number\(a\.observation_window_s \|\| 0\) - Number\(b\.observation_window_s \|\| 0\)\)\s*\n\s*: \[\];/,
+  );
+  expect(sortMatch).not.toBeNull();
+
+  const enabledMatch = source.match(/const predictionEnabled = ([^;]+);/);
+  expect(enabledMatch?.[1]).toBe(
+    'window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true || predictionCheckpoints.length > 0',
+  );
+
+  return {
+    sortCheckpoints: (data: { prediction_checkpoints?: Array<Record<string, unknown>> }) => (
+      Array.isArray(data.prediction_checkpoints)
+        ? [...data.prediction_checkpoints].sort(
+          (a, b) => Number(a.observation_window_s || 0) - Number(b.observation_window_s || 0),
+        )
+        : []
+    ),
+    evaluateEnabled: (predictiveReliability: boolean, checkpointCount: number) => Function(
+      'window',
+      'predictionCheckpoints',
+      `return ${enabledMatch?.[1]};`,
+    )(
+      { BUILD_PROCESS_WATCHER_CONFIG: { predictiveReliability } },
+      { length: checkpointCount },
+    ),
+  };
+}
+
+describe('run dashboard predictions tab', () => {
+  const sources = [
+    { name: 'run dashboard', source: fs.readFileSync(runDashboardPath, 'utf8') },
+    { name: 'demo dashboard', source: fs.readFileSync(demoDashboardPath, 'utf8') },
+  ];
+
+  it.each(sources)('$name exposes Dashboard and Predictions tabs', ({ source }) => {
+    expect(source).toContain('run-dashboard-tabs');
+    expect(source).toContain('data-run-tab="dashboard"');
+    expect(source).toContain('data-run-tab="predictions"');
+    expect(source).toContain('run-panel-predictions');
+    expect(source).toContain('predictionTabHtml');
+    expect(source).toContain('predictionPreviewHtml');
+    expect(source).toContain('No prediction checkpoints');
+    expect(source).toContain('activeRunDashboardTab');
+    expect(source).toContain('bindRunDashboardTabs');
+    expect(source).toContain('risk_score');
+    expect(source).toContain('provider_id');
+    expect(source).toContain('model_version');
+    expect(source).not.toContain('${predictionHtml}');
+  });
+
+  it('renders ready checkpoints when prediction_checkpoints are present', () => {
+    const { sortCheckpoints, evaluateEnabled } = extractPredictionHelpers(sources[0].source);
+    const checkpoints = sortCheckpoints({
+      prediction_checkpoints: [
+        {
+          observation_window_s: 180,
+          status: 'ready',
+          risk_level: 'elevated',
+          risk_score: 0.4,
+          confidence: 'medium',
+          predicted_peak_rss_mb: 3080.7,
+          predicted_duration_s: 199.7,
+          signals: ['memory pressure'],
+          provider_id: 'private-provider',
+          model_version: 'private-heuristic-v1',
+        },
+        {
+          observation_window_s: 30,
+          status: 'ready',
+          risk_level: 'elevated',
+          risk_score: 0.4,
+          confidence: 'medium',
+          predicted_peak_rss_mb: 1967.3,
+          predicted_duration_s: 32.2,
+          signals: ['rapid memory growth'],
+        },
+        {
+          observation_window_s: 60,
+          status: 'pending',
+          risk_level: 'unknown',
+        },
+      ],
+    });
+
+    expect(checkpoints.map(checkpoint => checkpoint.observation_window_s)).toEqual([30, 60, 180]);
+    expect(checkpoints.filter(checkpoint => checkpoint.status === 'ready')).toHaveLength(2);
+    expect(evaluateEnabled(false, checkpoints.length)).toBe(true);
+    expect(sources[0].source).toContain('Open Predictions');
+    expect(sources[0].source).toContain('Checkpoint Windows');
+  });
+
+  it('keeps legacy runs without prediction_checkpoints valid and empty-state ready', () => {
+    const { sortCheckpoints, evaluateEnabled } = extractPredictionHelpers(sources[0].source);
+    const demoData = JSON.parse(fs.readFileSync(demoDataPath, 'utf8'));
+
+    expect(demoData.prediction_checkpoints).toBeUndefined();
+    expect(sortCheckpoints({})).toEqual([]);
+    expect(sortCheckpoints({ prediction_checkpoints: undefined })).toEqual([]);
+    expect(evaluateEnabled(false, 0)).toBe(false);
+    expect(evaluateEnabled(true, 0)).toBe(true);
+    expect(sources[0].source).toContain('Legacy runs and deployments without predictive reliability omit this data.');
+    expect(sources[0].source).toContain('Checkpoints will appear here as observation windows complete.');
+  });
+});

--- a/__tests__/run-dashboard-responsive.test.ts
+++ b/__tests__/run-dashboard-responsive.test.ts
@@ -18,7 +18,9 @@ describe('run dashboard responsive layout', () => {
   it('renders predictive reliability when checkpoints are present even if config is disabled', () => {
     expect(source).toContain('prediction_checkpoints');
     expect(source).toContain('window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true || predictionCheckpoints.length > 0');
-    expect(source).toContain('predictionEnabled && predictionCheckpoints.length');
+    expect(source).toContain('predictionTabHtml');
+    expect(source).toContain('predictionPreviewHtml');
+    expect(source).toContain('data-run-tab="predictions"');
 
     const predicate = source.match(/const predictionEnabled = ([^;]+);/)?.[1];
     expect(predicate).toBeDefined();

--- a/frontend/public/bpw-ui.css
+++ b/frontend/public/bpw-ui.css
@@ -217,6 +217,109 @@ input[type="file"] {
     box-shadow: var(--bpw-shadow);
 }
 
+.run-dashboard-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin: 0 0 1rem;
+    padding: 0.25rem;
+    border: 1px solid rgba(22, 26, 29, 0.09);
+    border-radius: 8px;
+    background: rgba(245, 247, 251, 0.9);
+}
+
+.run-dashboard-tab {
+    appearance: none;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--bpw-muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.86rem;
+    font-weight: 650;
+    min-height: 2.1rem;
+    min-width: 7.5rem;
+    padding: 0.4rem 0.85rem;
+}
+
+.run-dashboard-tab.is-active,
+.run-dashboard-tab[aria-selected="true"] {
+    background: #fff;
+    border-color: var(--bpw-line);
+    color: var(--bpw-ink);
+    box-shadow: 0 1px 2px rgba(22, 26, 29, 0.06);
+}
+
+.run-dashboard-panel[hidden] {
+    display: none !important;
+}
+
+.prediction-preview {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin: 0 0 1.2rem;
+    padding: 0.85rem 1rem;
+    border: 1px solid rgba(22, 26, 29, 0.09);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: var(--bpw-shadow);
+    min-height: 3.6rem;
+}
+
+.prediction-preview-main {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.45rem 0.75rem;
+    min-width: 0;
+}
+
+.prediction-preview-main strong {
+    color: var(--bpw-ink);
+    font-size: 0.95rem;
+}
+
+.prediction-preview-main span:last-child {
+    color: var(--bpw-muted);
+    font-size: 0.82rem;
+}
+
+.prediction-panel-meta {
+    color: var(--bpw-muted);
+    font-size: 0.8rem;
+    white-space: nowrap;
+}
+
+.prediction-empty {
+    margin: 0;
+    padding: 1.25rem 1rem;
+    border: 1px solid rgba(22, 26, 29, 0.09);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: var(--bpw-shadow);
+    min-height: 8.5rem;
+}
+
+.prediction-empty h2 {
+    margin: 0.35rem 0 0.45rem;
+    color: var(--bpw-ink);
+    font-size: 1.05rem;
+}
+
+.prediction-empty p {
+    margin: 0;
+    color: var(--bpw-muted);
+    font-size: 0.88rem;
+    max-width: 42rem;
+}
+
+.prediction-timeline {
+    align-items: stretch;
+}
+
 .prediction-panel-head {
     display: flex;
     align-items: center;
@@ -240,6 +343,7 @@ input[type="file"] {
 
 .prediction-card {
     min-width: 0;
+    min-height: 11.5rem;
     padding: 0.85rem;
     border: 1px solid var(--bpw-line);
     border-radius: 8px;
@@ -258,6 +362,15 @@ input[type="file"] {
     border-color: #93c5a3;
 }
 
+.prediction-card.status-pending,
+.prediction-card.status-skipped {
+    opacity: 0.82;
+}
+
+.prediction-card.status-error {
+    border-color: #e8a0a0;
+}
+
 .prediction-card-top {
     display: flex;
     align-items: center;
@@ -270,18 +383,30 @@ input[type="file"] {
     font-size: 1rem;
 }
 
-.prediction-card-top span {
+.prediction-card-top span,
+.prediction-status {
     color: var(--bpw-muted);
     font-size: 0.78rem;
     text-transform: capitalize;
 }
 
 .prediction-risk {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
     margin-top: 0.5rem;
     color: var(--bpw-ink);
     font-size: 1.18rem;
     font-weight: 780;
     text-transform: capitalize;
+}
+
+.prediction-risk-score {
+    color: var(--bpw-muted);
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: none;
 }
 
 .prediction-metrics {
@@ -302,6 +427,7 @@ input[type="file"] {
     margin-top: 0.15rem;
     color: var(--bpw-ink);
     font-size: 0.84rem;
+    overflow-wrap: anywhere;
 }
 
 .prediction-signals {
@@ -318,6 +444,13 @@ input[type="file"] {
     background: #f5f7fb;
     color: var(--bpw-muted);
     font-size: 0.74rem;
+}
+
+.prediction-message {
+    margin: 0.65rem 0 0;
+    color: var(--bpw-muted);
+    font-size: 0.78rem;
+    line-height: 1.4;
 }
 
 .chart-container,
@@ -869,6 +1002,20 @@ footer {
 
     .run-kpi-strip,
     .status-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .prediction-preview {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .run-dashboard-tab {
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+
+    .prediction-metrics {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 

--- a/frontend/public/runs/[runId].html
+++ b/frontend/public/runs/[runId].html
@@ -486,6 +486,7 @@
         let refreshInterval = parseInt(localStorage.getItem('refreshInterval')) || 60; // Default 60 seconds
         let refreshTimer = null;
         let lastRefreshTime = null;
+        let activeRunDashboardTab = 'dashboard';
         
         if (!runId || runId === 'runs' || runId === '') {
             document.getElementById('content').innerHTML = `
@@ -518,6 +519,53 @@
                 clearTimeout(refreshTimer);
                 refreshTimer = null;
             }
+        }
+
+        function resizeRunDashboardCharts() {
+            if (!window.Plotly || typeof Plotly.Plots?.resize !== 'function') return;
+            [
+                'chart',
+                'gc-chart',
+                'rss-heap-chart',
+                'jit-time-chart',
+                'classes-loaded-chart',
+                'class-rate-chart',
+            ].forEach((id) => {
+                const el = document.getElementById(id);
+                if (!el) return;
+                try {
+                    Plotly.Plots.resize(el);
+                } catch (_) {
+                    // Chart may not be initialized yet.
+                }
+            });
+        }
+
+        function setRunDashboardTab(tab) {
+            activeRunDashboardTab = tab === 'predictions' ? 'predictions' : 'dashboard';
+            const tabs = document.querySelectorAll('.run-dashboard-tab[data-run-tab]');
+            const dashboardPanel = document.getElementById('run-panel-dashboard');
+            const predictionsPanel = document.getElementById('run-panel-predictions');
+            tabs.forEach((button) => {
+                const selected = button.getAttribute('data-run-tab') === activeRunDashboardTab;
+                button.classList.toggle('is-active', selected);
+                button.setAttribute('aria-selected', selected ? 'true' : 'false');
+                button.tabIndex = selected ? 0 : -1;
+            });
+            if (dashboardPanel) dashboardPanel.hidden = activeRunDashboardTab !== 'dashboard';
+            if (predictionsPanel) predictionsPanel.hidden = activeRunDashboardTab !== 'predictions';
+            if (activeRunDashboardTab === 'dashboard') {
+                requestAnimationFrame(() => resizeRunDashboardCharts());
+            }
+        }
+
+        function bindRunDashboardTabs() {
+            document.querySelectorAll('[data-run-tab]').forEach((el) => {
+                el.addEventListener('click', () => {
+                    setRunDashboardTab(el.getAttribute('data-run-tab'));
+                });
+            });
+            setRunDashboardTab(activeRunDashboardTab || 'dashboard');
         }
 
         async function loadRunData(runId) {
@@ -661,36 +709,85 @@
             
             const formatDur = (s) => s < 60 ? s + 's' : (Math.floor(s / 60) + 'm' + (s % 60 ? ' ' + Math.round(s % 60) + 's' : ''));
             const formatPredictionValue = (value, unit) => Number.isFinite(Number(value)) ? `${Number(value).toFixed(Number(value) >= 1000 ? 0 : 1)} ${unit}` : 'N/A';
+            const formatRiskScore = (score) => {
+                if (!Number.isFinite(Number(score))) return 'N/A';
+                const n = Number(score);
+                if (n <= 1 && n >= 0) return n.toFixed(2);
+                return n >= 100 ? n.toFixed(0) : n.toFixed(1);
+            };
             const predictionRiskClass = (riskLevel) => ['low', 'elevated', 'high'].includes(riskLevel) ? riskLevel : 'unknown';
+            const predictionStatusClass = (status) => ['ready', 'pending', 'skipped', 'error'].includes(status) ? status : 'unknown';
             const predictionCheckpoints = Array.isArray(data.prediction_checkpoints)
                 ? [...data.prediction_checkpoints].sort((a, b) => Number(a.observation_window_s || 0) - Number(b.observation_window_s || 0))
                 : [];
             const predictionEnabled = window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true || predictionCheckpoints.length > 0;
-            const predictionHtml = predictionEnabled && predictionCheckpoints.length ? `
-                <section class="prediction-panel" aria-label="Predictive reliability">
+            const readyPredictionCount = predictionCheckpoints.filter(checkpoint => checkpoint.status === 'ready').length;
+            const latestReadyRisk = [...predictionCheckpoints].reverse().find(checkpoint => checkpoint.status === 'ready')?.risk_level;
+            const renderPredictionCard = (checkpoint) => {
+                const status = checkpoint.status || 'unknown';
+                const riskLevel = checkpoint.risk_level || 'unknown';
+                const providerBits = [];
+                if (checkpoint.provider_id) providerBits.push(`<div><span>Provider</span><strong>${escapeHtml(checkpoint.provider_id)}</strong></div>`);
+                if (checkpoint.model_version) providerBits.push(`<div><span>Model</span><strong>${escapeHtml(checkpoint.model_version)}</strong></div>`);
+                const signalHtml = Array.isArray(checkpoint.signals) && checkpoint.signals.length
+                    ? `<div class="prediction-signals">${checkpoint.signals.slice(0, 4).map(signal => `<span>${escapeHtml(signal)}</span>`).join('')}</div>`
+                    : '';
+                const messageHtml = checkpoint.message && (status === 'error' || status === 'skipped')
+                    ? `<p class="prediction-message">${escapeHtml(checkpoint.message)}</p>`
+                    : '';
+                return `
+                    <article class="prediction-card ${predictionRiskClass(riskLevel)} status-${predictionStatusClass(status)}">
+                        <div class="prediction-card-top">
+                            <strong>${escapeHtml(String(checkpoint.observation_window_s || 'N/A'))}s</strong>
+                            <span class="prediction-status">${escapeHtml(status)}</span>
+                        </div>
+                        <div class="prediction-risk">
+                            <span class="prediction-risk-level">${escapeHtml(riskLevel)}</span>
+                            ${Number.isFinite(Number(checkpoint.risk_score))
+                                ? `<span class="prediction-risk-score">score ${escapeHtml(formatRiskScore(checkpoint.risk_score))}</span>`
+                                : ''}
+                        </div>
+                        <div class="prediction-metrics">
+                            <div><span>Confidence</span><strong>${escapeHtml(checkpoint.confidence || 'N/A')}</strong></div>
+                            <div><span>Peak RSS</span><strong>${formatPredictionValue(checkpoint.predicted_peak_rss_mb, 'MB')}</strong></div>
+                            <div><span>Duration</span><strong>${formatPredictionValue(checkpoint.predicted_duration_s, 's')}</strong></div>
+                            ${providerBits.join('')}
+                        </div>
+                        ${signalHtml}
+                        ${messageHtml}
+                    </article>
+                `;
+            };
+            const predictionTabHtml = predictionCheckpoints.length ? `
+                <section class="prediction-panel prediction-tab-panel" aria-label="Prediction checkpoints">
                     <div class="prediction-panel-head">
                         <div>
-                            <span class="bpw-panel-badge">Prediction</span>
-                            <h2>Reliability Checkpoints</h2>
+                            <span class="bpw-panel-badge">Predictions</span>
+                            <h2>Checkpoint Windows</h2>
                         </div>
+                        <div class="prediction-panel-meta">${readyPredictionCount}/${predictionCheckpoints.length} ready</div>
                     </div>
-                    <div class="prediction-grid">
-                        ${predictionCheckpoints.map(checkpoint => `
-                            <article class="prediction-card ${predictionRiskClass(checkpoint.risk_level)}">
-                                <div class="prediction-card-top">
-                                    <strong>${escapeHtml(String(checkpoint.observation_window_s || 'N/A'))}s</strong>
-                                    <span>${escapeHtml(checkpoint.status || 'unknown')}</span>
-                                </div>
-                                <div class="prediction-risk">${escapeHtml(checkpoint.risk_level || 'unknown')}</div>
-                                <div class="prediction-metrics">
-                                    <div><span>Confidence</span><strong>${escapeHtml(checkpoint.confidence || 'N/A')}</strong></div>
-                                    <div><span>Peak RSS</span><strong>${formatPredictionValue(checkpoint.predicted_peak_rss_mb, 'MB')}</strong></div>
-                                    <div><span>Duration</span><strong>${formatPredictionValue(checkpoint.predicted_duration_s, 's')}</strong></div>
-                                </div>
-                                ${Array.isArray(checkpoint.signals) && checkpoint.signals.length ? `<div class="prediction-signals">${checkpoint.signals.slice(0, 3).map(signal => `<span>${escapeHtml(signal)}</span>`).join('')}</div>` : ''}
-                            </article>
-                        `).join('')}
+                    <div class="prediction-grid prediction-timeline">
+                        ${predictionCheckpoints.map(renderPredictionCard).join('')}
                     </div>
+                </section>
+            ` : `
+                <section class="prediction-empty" aria-label="Prediction checkpoints">
+                    <span class="bpw-panel-badge">Predictions</span>
+                    <h2>No prediction checkpoints</h2>
+                    <p>${predictionEnabled
+                        ? 'Checkpoints will appear here as observation windows complete.'
+                        : 'This run has no prediction_checkpoints. Legacy runs and deployments without predictive reliability omit this data.'}</p>
+                </section>
+            `;
+            const predictionPreviewHtml = predictionCheckpoints.length ? `
+                <section class="prediction-preview" aria-label="Prediction preview">
+                    <div class="prediction-preview-main">
+                        <span class="bpw-panel-badge">Predictions</span>
+                        <strong>${predictionCheckpoints.length} checkpoint${predictionCheckpoints.length === 1 ? '' : 's'}</strong>
+                        <span>${readyPredictionCount} ready${latestReadyRisk ? ` · latest risk ${escapeHtml(latestReadyRisk)}` : ''}</span>
+                    </div>
+                    <button type="button" class="btn secondary" data-run-tab="predictions">Open Predictions</button>
                 </section>
             ` : '';
 
@@ -826,6 +923,12 @@
                     </div>
                 </div>
 
+                <div class="run-dashboard-tabs" role="tablist" aria-label="Run dashboard views">
+                    <button type="button" class="run-dashboard-tab" role="tab" id="run-tab-dashboard" data-run-tab="dashboard" aria-controls="run-panel-dashboard">Dashboard</button>
+                    <button type="button" class="run-dashboard-tab" role="tab" id="run-tab-predictions" data-run-tab="predictions" aria-controls="run-panel-predictions">Predictions</button>
+                </div>
+
+                <div id="run-panel-dashboard" class="run-dashboard-panel" role="tabpanel" aria-labelledby="run-tab-dashboard">
                 <div class="run-kpi-strip">
                     <div class="run-kpi">
                         <div class="run-kpi-label">Peak RSS</div>
@@ -849,7 +952,7 @@
                     </div>
                 </div>
 
-                ${predictionHtml}
+                ${predictionPreviewHtml}
 
                 <!-- Compare runs hidden until ready -->
 
@@ -1152,6 +1255,11 @@
                 ` : ''}
 
                 <div id="compare-section" class="compare-section" style="display: none;"></div>
+                </div>
+
+                <div id="run-panel-predictions" class="run-dashboard-panel" role="tabpanel" aria-labelledby="run-tab-predictions" hidden>
+                    ${predictionTabHtml}
+                </div>
             `;
 
             if (samples.length > 0) {
@@ -1217,6 +1325,8 @@
                     BpwExperimentLayout.initPanelFocusButtons?.();
                 }
             }
+
+            bindRunDashboardTabs();
         }
 
         function shouldShowRssHeapRatioChart(samples) {

--- a/frontend/public/runs/demo.html
+++ b/frontend/public/runs/demo.html
@@ -495,6 +495,7 @@
         let refreshInterval = parseInt(localStorage.getItem('refreshInterval')) || 60; // Default 60 seconds
         let refreshTimer = null;
         let lastRefreshTime = null;
+        let activeRunDashboardTab = 'dashboard';
 
         if (!runId || runId === 'runs' || runId === '') {
             document.getElementById('content').innerHTML = `
@@ -527,6 +528,53 @@
                 clearTimeout(refreshTimer);
                 refreshTimer = null;
             }
+        }
+
+        function resizeRunDashboardCharts() {
+            if (!window.Plotly || typeof Plotly.Plots?.resize !== 'function') return;
+            [
+                'chart',
+                'gc-chart',
+                'rss-heap-chart',
+                'jit-time-chart',
+                'classes-loaded-chart',
+                'class-rate-chart',
+            ].forEach((id) => {
+                const el = document.getElementById(id);
+                if (!el) return;
+                try {
+                    Plotly.Plots.resize(el);
+                } catch (_) {
+                    // Chart may not be initialized yet.
+                }
+            });
+        }
+
+        function setRunDashboardTab(tab) {
+            activeRunDashboardTab = tab === 'predictions' ? 'predictions' : 'dashboard';
+            const tabs = document.querySelectorAll('.run-dashboard-tab[data-run-tab]');
+            const dashboardPanel = document.getElementById('run-panel-dashboard');
+            const predictionsPanel = document.getElementById('run-panel-predictions');
+            tabs.forEach((button) => {
+                const selected = button.getAttribute('data-run-tab') === activeRunDashboardTab;
+                button.classList.toggle('is-active', selected);
+                button.setAttribute('aria-selected', selected ? 'true' : 'false');
+                button.tabIndex = selected ? 0 : -1;
+            });
+            if (dashboardPanel) dashboardPanel.hidden = activeRunDashboardTab !== 'dashboard';
+            if (predictionsPanel) predictionsPanel.hidden = activeRunDashboardTab !== 'predictions';
+            if (activeRunDashboardTab === 'dashboard') {
+                requestAnimationFrame(() => resizeRunDashboardCharts());
+            }
+        }
+
+        function bindRunDashboardTabs() {
+            document.querySelectorAll('[data-run-tab]').forEach((el) => {
+                el.addEventListener('click', () => {
+                    setRunDashboardTab(el.getAttribute('data-run-tab'));
+                });
+            });
+            setRunDashboardTab(activeRunDashboardTab || 'dashboard');
         }
 
         async function loadRunData(runId) {
@@ -669,36 +717,85 @@
 
             const formatDur = (s) => s < 60 ? s + 's' : (Math.floor(s / 60) + 'm' + (s % 60 ? ' ' + Math.round(s % 60) + 's' : ''));
             const formatPredictionValue = (value, unit) => Number.isFinite(Number(value)) ? `${Number(value).toFixed(Number(value) >= 1000 ? 0 : 1)} ${unit}` : 'N/A';
+            const formatRiskScore = (score) => {
+                if (!Number.isFinite(Number(score))) return 'N/A';
+                const n = Number(score);
+                if (n <= 1 && n >= 0) return n.toFixed(2);
+                return n >= 100 ? n.toFixed(0) : n.toFixed(1);
+            };
             const predictionRiskClass = (riskLevel) => ['low', 'elevated', 'high'].includes(riskLevel) ? riskLevel : 'unknown';
+            const predictionStatusClass = (status) => ['ready', 'pending', 'skipped', 'error'].includes(status) ? status : 'unknown';
             const predictionCheckpoints = Array.isArray(data.prediction_checkpoints)
                 ? [...data.prediction_checkpoints].sort((a, b) => Number(a.observation_window_s || 0) - Number(b.observation_window_s || 0))
                 : [];
             const predictionEnabled = window.BUILD_PROCESS_WATCHER_CONFIG?.predictiveReliability === true || predictionCheckpoints.length > 0;
-            const predictionHtml = predictionEnabled && predictionCheckpoints.length ? `
-                <section class="prediction-panel" aria-label="Predictive reliability">
+            const readyPredictionCount = predictionCheckpoints.filter(checkpoint => checkpoint.status === 'ready').length;
+            const latestReadyRisk = [...predictionCheckpoints].reverse().find(checkpoint => checkpoint.status === 'ready')?.risk_level;
+            const renderPredictionCard = (checkpoint) => {
+                const status = checkpoint.status || 'unknown';
+                const riskLevel = checkpoint.risk_level || 'unknown';
+                const providerBits = [];
+                if (checkpoint.provider_id) providerBits.push(`<div><span>Provider</span><strong>${escapeHtml(checkpoint.provider_id)}</strong></div>`);
+                if (checkpoint.model_version) providerBits.push(`<div><span>Model</span><strong>${escapeHtml(checkpoint.model_version)}</strong></div>`);
+                const signalHtml = Array.isArray(checkpoint.signals) && checkpoint.signals.length
+                    ? `<div class="prediction-signals">${checkpoint.signals.slice(0, 4).map(signal => `<span>${escapeHtml(signal)}</span>`).join('')}</div>`
+                    : '';
+                const messageHtml = checkpoint.message && (status === 'error' || status === 'skipped')
+                    ? `<p class="prediction-message">${escapeHtml(checkpoint.message)}</p>`
+                    : '';
+                return `
+                    <article class="prediction-card ${predictionRiskClass(riskLevel)} status-${predictionStatusClass(status)}">
+                        <div class="prediction-card-top">
+                            <strong>${escapeHtml(String(checkpoint.observation_window_s || 'N/A'))}s</strong>
+                            <span class="prediction-status">${escapeHtml(status)}</span>
+                        </div>
+                        <div class="prediction-risk">
+                            <span class="prediction-risk-level">${escapeHtml(riskLevel)}</span>
+                            ${Number.isFinite(Number(checkpoint.risk_score))
+                                ? `<span class="prediction-risk-score">score ${escapeHtml(formatRiskScore(checkpoint.risk_score))}</span>`
+                                : ''}
+                        </div>
+                        <div class="prediction-metrics">
+                            <div><span>Confidence</span><strong>${escapeHtml(checkpoint.confidence || 'N/A')}</strong></div>
+                            <div><span>Peak RSS</span><strong>${formatPredictionValue(checkpoint.predicted_peak_rss_mb, 'MB')}</strong></div>
+                            <div><span>Duration</span><strong>${formatPredictionValue(checkpoint.predicted_duration_s, 's')}</strong></div>
+                            ${providerBits.join('')}
+                        </div>
+                        ${signalHtml}
+                        ${messageHtml}
+                    </article>
+                `;
+            };
+            const predictionTabHtml = predictionCheckpoints.length ? `
+                <section class="prediction-panel prediction-tab-panel" aria-label="Prediction checkpoints">
                     <div class="prediction-panel-head">
                         <div>
-                            <span class="bpw-panel-badge">Prediction</span>
-                            <h2>Reliability Checkpoints</h2>
+                            <span class="bpw-panel-badge">Predictions</span>
+                            <h2>Checkpoint Windows</h2>
                         </div>
+                        <div class="prediction-panel-meta">${readyPredictionCount}/${predictionCheckpoints.length} ready</div>
                     </div>
-                    <div class="prediction-grid">
-                        ${predictionCheckpoints.map(checkpoint => `
-                            <article class="prediction-card ${predictionRiskClass(checkpoint.risk_level)}">
-                                <div class="prediction-card-top">
-                                    <strong>${escapeHtml(String(checkpoint.observation_window_s || 'N/A'))}s</strong>
-                                    <span>${escapeHtml(checkpoint.status || 'unknown')}</span>
-                                </div>
-                                <div class="prediction-risk">${escapeHtml(checkpoint.risk_level || 'unknown')}</div>
-                                <div class="prediction-metrics">
-                                    <div><span>Confidence</span><strong>${escapeHtml(checkpoint.confidence || 'N/A')}</strong></div>
-                                    <div><span>Peak RSS</span><strong>${formatPredictionValue(checkpoint.predicted_peak_rss_mb, 'MB')}</strong></div>
-                                    <div><span>Duration</span><strong>${formatPredictionValue(checkpoint.predicted_duration_s, 's')}</strong></div>
-                                </div>
-                                ${Array.isArray(checkpoint.signals) && checkpoint.signals.length ? `<div class="prediction-signals">${checkpoint.signals.slice(0, 3).map(signal => `<span>${escapeHtml(signal)}</span>`).join('')}</div>` : ''}
-                            </article>
-                        `).join('')}
+                    <div class="prediction-grid prediction-timeline">
+                        ${predictionCheckpoints.map(renderPredictionCard).join('')}
                     </div>
+                </section>
+            ` : `
+                <section class="prediction-empty" aria-label="Prediction checkpoints">
+                    <span class="bpw-panel-badge">Predictions</span>
+                    <h2>No prediction checkpoints</h2>
+                    <p>${predictionEnabled
+                        ? 'Checkpoints will appear here as observation windows complete.'
+                        : 'This run has no prediction_checkpoints. Legacy runs and deployments without predictive reliability omit this data.'}</p>
+                </section>
+            `;
+            const predictionPreviewHtml = predictionCheckpoints.length ? `
+                <section class="prediction-preview" aria-label="Prediction preview">
+                    <div class="prediction-preview-main">
+                        <span class="bpw-panel-badge">Predictions</span>
+                        <strong>${predictionCheckpoints.length} checkpoint${predictionCheckpoints.length === 1 ? '' : 's'}</strong>
+                        <span>${readyPredictionCount} ready${latestReadyRisk ? ` · latest risk ${escapeHtml(latestReadyRisk)}` : ''}</span>
+                    </div>
+                    <button type="button" class="btn secondary" data-run-tab="predictions">Open Predictions</button>
                 </section>
             ` : '';
 
@@ -834,6 +931,12 @@
                     </div>
                 </div>
 
+                <div class="run-dashboard-tabs" role="tablist" aria-label="Run dashboard views">
+                    <button type="button" class="run-dashboard-tab" role="tab" id="run-tab-dashboard" data-run-tab="dashboard" aria-controls="run-panel-dashboard">Dashboard</button>
+                    <button type="button" class="run-dashboard-tab" role="tab" id="run-tab-predictions" data-run-tab="predictions" aria-controls="run-panel-predictions">Predictions</button>
+                </div>
+
+                <div id="run-panel-dashboard" class="run-dashboard-panel" role="tabpanel" aria-labelledby="run-tab-dashboard">
                 <div class="run-kpi-strip">
                     <div class="run-kpi">
                         <div class="run-kpi-label">Peak RSS</div>
@@ -857,7 +960,7 @@
                     </div>
                 </div>
 
-                ${predictionHtml}
+                ${predictionPreviewHtml}
 
                 <!-- Compare runs hidden until ready -->
 
@@ -1160,6 +1263,11 @@
                 ` : ''}
 
                 <div id="compare-section" class="compare-section" style="display: none;"></div>
+                </div>
+
+                <div id="run-panel-predictions" class="run-dashboard-panel" role="tabpanel" aria-labelledby="run-tab-predictions" hidden>
+                    ${predictionTabHtml}
+                </div>
             `;
 
             if (samples.length > 0) {
@@ -1225,6 +1333,8 @@
                     BpwExperimentLayout.initPanelFocusButtons?.();
                 }
             }
+
+            bindRunDashboardTabs();
         }
 
         function shouldShowRssHeapRatioChart(samples) {


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/build-process-watcher#138: Add Predictions tab to run dashboard

Fixes #138

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `medium`

## Verification

- `npm test -- --runInBand`