### PR TITLE
fix: refactor fallback classification to a scoring boundary

### DIFF
--- a/backend/internal/handlers/BUILD.bazel
+++ b/backend/internal/handlers/BUILD.bazel
@@ -21,6 +21,5 @@ go_test(
     embed = [":handlers"],
     deps = [
         "//internal/models",
-        "//internal/scoring",
     ],
 )

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -261,10 +260,10 @@ func (h *Handlers) evaluatePredictionCheckpoints(ctx context.Context, runID stri
 			Now:                   time.Now(),
 		}, checkpointWindow)
 		if err != nil {
-			fallbackStatus, fallbackMessage := classifyPredictionFallback(err)
+			fallbackState, fallbackMessage := scoring.ClassifyFallback(err)
 			checkpoint = models.PredictionCheckpoint{
 				ObservationWindowS: checkpointWindow,
-				Status:             fallbackStatus,
+				Status:             string(fallbackState),
 				CreatedAt:          time.Now(),
 				Message:            fallbackMessage,
 			}
@@ -281,21 +280,6 @@ func (h *Handlers) evaluatePredictionCheckpoints(ctx context.Context, runID stri
 			continue
 		}
 		runDoc.PredictionCheckpoints = storage.MergePredictionCheckpoint(runDoc.PredictionCheckpoints, checkpoint)
-	}
-}
-
-// classifyPredictionFallback maps provider failures onto the shared scoring
-// taxonomy without importing a concrete provider implementation.
-func classifyPredictionFallback(err error) (status string, message string) {
-	switch {
-	case errors.Is(err, scoring.ErrNoData):
-		return "no_data", "prediction data unavailable"
-	case errors.Is(err, scoring.ErrModelUnavailable):
-		return "model_unavailable", "prediction model unavailable"
-	case errors.Is(err, scoring.ErrScoringTimeout), errors.Is(err, scoring.ErrScoringFailed):
-		return "provider_error", "prediction provider error"
-	default:
-		return "provider_error", "prediction provider error"
 	}
 }
 

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -2,13 +2,11 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/cdsap/build-process-watcher/backend/internal/models"
-	"github.com/cdsap/build-process-watcher/backend/internal/scoring"
 )
 
 func TestIngestHandler_RequestWithProcessInfo(t *testing.T) {
@@ -61,58 +59,6 @@ func TestBoolQueryAcceptsExplicitTrueOnly(t *testing.T) {
 	request = httptest.NewRequest("POST", "/auth/run/run-1?predictive_reliability=maybe", nil)
 	if boolQuery(request, "predictive_reliability") {
 		t.Fatal("expected invalid predictive_reliability value to be rejected")
-	}
-}
-
-func TestClassifyPredictionFallbackUsesSharedScoringTaxonomy(t *testing.T) {
-	tests := []struct {
-		name        string
-		err         error
-		wantStatus  string
-		wantMessage string
-	}{
-		{
-			name:        "no data",
-			err:         fmt.Errorf("provider context: %w", scoring.ErrNoData),
-			wantStatus:  "no_data",
-			wantMessage: "prediction data unavailable",
-		},
-		{
-			name:        "model unavailable",
-			err:         fmt.Errorf("provider context: %w", scoring.ErrModelUnavailable),
-			wantStatus:  "model_unavailable",
-			wantMessage: "prediction model unavailable",
-		},
-		{
-			name:        "scoring failed",
-			err:         fmt.Errorf("provider context: %w", scoring.ErrScoringFailed),
-			wantStatus:  "provider_error",
-			wantMessage: "prediction provider error",
-		},
-		{
-			name:        "scoring timeout",
-			err:         fmt.Errorf("provider context: %w", scoring.ErrScoringTimeout),
-			wantStatus:  "provider_error",
-			wantMessage: "prediction provider error",
-		},
-		{
-			name:        "unknown error",
-			err:         fmt.Errorf("unexpected provider failure"),
-			wantStatus:  "provider_error",
-			wantMessage: "prediction provider error",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotStatus, gotMessage := classifyPredictionFallback(tt.err)
-			if gotStatus != tt.wantStatus {
-				t.Fatalf("status = %q, want %q", gotStatus, tt.wantStatus)
-			}
-			if gotMessage != tt.wantMessage {
-				t.Fatalf("message = %q, want %q", gotMessage, tt.wantMessage)
-			}
-		})
 	}
 }
 

--- a/backend/internal/scoring/BUILD.bazel
+++ b/backend/internal/scoring/BUILD.bazel
@@ -1,8 +1,14 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "scoring",
     srcs = ["errors.go"],
     importpath = "github.com/cdsap/build-process-watcher/backend/internal/scoring",
     visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "scoring_test",
+    srcs = ["errors_test.go"],
+    embed = [":scoring"],
 )

--- a/backend/internal/scoring/errors.go
+++ b/backend/internal/scoring/errors.go
@@ -8,3 +8,27 @@ var (
 	ErrScoringFailed    = errors.New("prediction scoring failed")
 	ErrModelUnavailable = errors.New("prediction model unavailable")
 )
+
+// State is the public-safe telemetry category recorded for a scoring fallback.
+type State string
+
+const (
+	StateNoData           State = "no_data"
+	StateModelUnavailable State = "model_unavailable"
+	StateProviderError    State = "provider_error"
+)
+
+// ClassifyFallback maps scoring sentinel errors onto telemetry state and the
+// matching public-safe checkpoint message. Unknown errors become provider_error.
+func ClassifyFallback(err error) (state State, message string) {
+	switch {
+	case errors.Is(err, ErrNoData):
+		return StateNoData, "prediction data unavailable"
+	case errors.Is(err, ErrModelUnavailable):
+		return StateModelUnavailable, "prediction model unavailable"
+	case errors.Is(err, ErrScoringTimeout), errors.Is(err, ErrScoringFailed):
+		return StateProviderError, "prediction provider error"
+	default:
+		return StateProviderError, "prediction provider error"
+	}
+}

--- a/backend/internal/scoring/errors_test.go
+++ b/backend/internal/scoring/errors_test.go
@@ -1,0 +1,58 @@
+package scoring
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestClassifyFallbackMapsSharedScoringTaxonomy(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantState   State
+		wantMessage string
+	}{
+		{
+			name:        "no data",
+			err:         fmt.Errorf("provider context: %w", ErrNoData),
+			wantState:   StateNoData,
+			wantMessage: "prediction data unavailable",
+		},
+		{
+			name:        "model unavailable",
+			err:         fmt.Errorf("provider context: %w", ErrModelUnavailable),
+			wantState:   StateModelUnavailable,
+			wantMessage: "prediction model unavailable",
+		},
+		{
+			name:        "scoring failed",
+			err:         fmt.Errorf("provider context: %w", ErrScoringFailed),
+			wantState:   StateProviderError,
+			wantMessage: "prediction provider error",
+		},
+		{
+			name:        "scoring timeout",
+			err:         fmt.Errorf("provider context: %w", ErrScoringTimeout),
+			wantState:   StateProviderError,
+			wantMessage: "prediction provider error",
+		},
+		{
+			name:        "unknown error",
+			err:         fmt.Errorf("unexpected provider failure"),
+			wantState:   StateProviderError,
+			wantMessage: "prediction provider error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotState, gotMessage := ClassifyFallback(tt.err)
+			if gotState != tt.wantState {
+				t.Fatalf("state = %q, want %q", gotState, tt.wantState)
+			}
+			if gotMessage != tt.wantMessage {
+				t.Fatalf("message = %q, want %q", gotMessage, tt.wantMessage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/build-process-watcher#140: Refactor fallback classification to a scoring boundary

Fixes #140

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `npm test -- --runInBand`