### PR TITLE
fix: refactor api fallback classification to provider-owned behavior

### DIFF
--- a/backend/internal/handlers/BUILD.bazel
+++ b/backend/internal/handlers/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//internal/auth",
         "//internal/exportqueue",
         "//internal/models",
-        "//internal/scoring",
         "//internal/storage",
         "//pkg/predictor",
     ],
@@ -21,5 +20,6 @@ go_test(
     embed = [":handlers"],
     deps = [
         "//internal/models",
+        "//pkg/predictor",
     ],
 )

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -13,10 +13,15 @@ import (
 	"github.com/cdsap/build-process-watcher/backend/internal/auth"
 	"github.com/cdsap/build-process-watcher/backend/internal/exportqueue"
 	"github.com/cdsap/build-process-watcher/backend/internal/models"
-	"github.com/cdsap/build-process-watcher/backend/internal/scoring"
 	"github.com/cdsap/build-process-watcher/backend/internal/storage"
 	"github.com/cdsap/build-process-watcher/backend/pkg/predictor"
 )
+
+// fallbackClassifier is an optional provider capability for scoring-domain
+// fallback telemetry. Providers that own sentinel errors should implement it.
+type fallbackClassifier interface {
+	ClassifyFallback(err error) (state string, message string)
+}
 
 // Handlers contains all HTTP handlers
 type Handlers struct {
@@ -260,10 +265,10 @@ func (h *Handlers) evaluatePredictionCheckpoints(ctx context.Context, runID stri
 			Now:                   time.Now(),
 		}, checkpointWindow)
 		if err != nil {
-			fallbackState, fallbackMessage := scoring.ClassifyFallback(err)
+			fallbackState, fallbackMessage := classifyFallback(h.predictor, err)
 			checkpoint = models.PredictionCheckpoint{
 				ObservationWindowS: checkpointWindow,
-				Status:             string(fallbackState),
+				Status:             fallbackState,
 				CreatedAt:          time.Now(),
 				Message:            fallbackMessage,
 			}
@@ -281,6 +286,15 @@ func (h *Handlers) evaluatePredictionCheckpoints(ctx context.Context, runID stri
 		}
 		runDoc.PredictionCheckpoints = storage.MergePredictionCheckpoint(runDoc.PredictionCheckpoints, checkpoint)
 	}
+}
+
+// classifyFallback uses a provider-owned classifier when available, otherwise
+// records a generic provider_error without inspecting scoring sentinel errors.
+func classifyFallback(provider predictor.Provider, err error) (state string, message string) {
+	if classifier, ok := provider.(fallbackClassifier); ok {
+		return classifier.ClassifyFallback(err)
+	}
+	return "provider_error", "prediction provider error"
 }
 
 func boolQuery(r *http.Request, key string) bool {

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -1,12 +1,15 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/cdsap/build-process-watcher/backend/internal/models"
+	"github.com/cdsap/build-process-watcher/backend/pkg/predictor"
 )
 
 func TestIngestHandler_RequestWithProcessInfo(t *testing.T) {
@@ -167,5 +170,50 @@ func TestRunResponse_WithPredictionCheckpoints(t *testing.T) {
 	}
 	if unmarshaled.PredictionCheckpoints[0].ObservationWindowS != 180 {
 		t.Fatalf("Prediction window = %d, want 180", unmarshaled.PredictionCheckpoints[0].ObservationWindowS)
+	}
+}
+
+// classifyingFakeProvider is a predictor.Provider test double that owns fallback
+// telemetry without importing scoring sentinel errors.
+type classifyingFakeProvider struct {
+	state   string
+	message string
+}
+
+func (classifyingFakeProvider) Predict(context.Context, predictor.RunSnapshot, int) (predictor.PredictionCheckpoint, error) {
+	return predictor.PredictionCheckpoint{}, errors.New("synthetic provider failure")
+}
+
+func (p classifyingFakeProvider) ClassifyFallback(error) (string, string) {
+	return p.state, p.message
+}
+
+type plainFakeProvider struct{}
+
+func (plainFakeProvider) Predict(context.Context, predictor.RunSnapshot, int) (predictor.PredictionCheckpoint, error) {
+	return predictor.PredictionCheckpoint{}, errors.New("synthetic provider failure")
+}
+
+func TestClassifyFallbackUsesProviderOwnedClassifier(t *testing.T) {
+	provider := classifyingFakeProvider{
+		state:   "no_data",
+		message: "prediction data unavailable",
+	}
+	state, message := classifyFallback(provider, errors.New("ignored by fake"))
+	if state != "no_data" {
+		t.Fatalf("state = %q, want no_data", state)
+	}
+	if message != "prediction data unavailable" {
+		t.Fatalf("message = %q, want prediction data unavailable", message)
+	}
+}
+
+func TestClassifyFallbackDefaultsWithoutClassifier(t *testing.T) {
+	state, message := classifyFallback(plainFakeProvider{}, errors.New("unexpected"))
+	if state != "provider_error" {
+		t.Fatalf("state = %q, want provider_error", state)
+	}
+	if message != "prediction provider error" {
+		t.Fatalf("message = %q, want prediction provider error", message)
 	}
 }

--- a/backend/pkg/predictor/BUILD.bazel
+++ b/backend/pkg/predictor/BUILD.bazel
@@ -22,4 +22,7 @@ go_test(
         "remote_test.go",
     ],
     embed = [":predictor"],
+    deps = [
+        "//internal/scoring",
+    ],
 )

--- a/backend/pkg/predictor/remote.go
+++ b/backend/pkg/predictor/remote.go
@@ -106,6 +106,13 @@ func (p *RemoteProvider) Predict(ctx context.Context, snapshot RunSnapshot, obse
 	return response.Checkpoint, nil
 }
 
+// ClassifyFallback maps remote scoring failures onto public-safe telemetry.
+// Handlers prefer this optional method over generic provider_error defaults.
+func (*RemoteProvider) ClassifyFallback(err error) (state string, message string) {
+	fallbackState, fallbackMessage := scoring.ClassifyFallback(err)
+	return string(fallbackState), fallbackMessage
+}
+
 type scoringError struct {
 	kind    error
 	message string

--- a/backend/pkg/predictor/remote_test.go
+++ b/backend/pkg/predictor/remote_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -125,6 +126,59 @@ func TestRemoteProviderClassifiesSharedScoringErrors(t *testing.T) {
 			}
 			if !errors.Is(err, tt.want) {
 				t.Fatalf("error = %v, want sentinel %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoteProviderClassifyFallbackMapsSharedTaxonomy(t *testing.T) {
+	provider := &RemoteProvider{}
+	tests := []struct {
+		name        string
+		err         error
+		wantState   string
+		wantMessage string
+	}{
+		{
+			name:        "no data",
+			err:         fmt.Errorf("provider context: %w", scoring.ErrNoData),
+			wantState:   string(scoring.StateNoData),
+			wantMessage: "prediction data unavailable",
+		},
+		{
+			name:        "model unavailable",
+			err:         fmt.Errorf("provider context: %w", scoring.ErrModelUnavailable),
+			wantState:   string(scoring.StateModelUnavailable),
+			wantMessage: "prediction model unavailable",
+		},
+		{
+			name:        "scoring failed",
+			err:         fmt.Errorf("provider context: %w", scoring.ErrScoringFailed),
+			wantState:   string(scoring.StateProviderError),
+			wantMessage: "prediction provider error",
+		},
+		{
+			name:        "scoring timeout",
+			err:         fmt.Errorf("provider context: %w", scoring.ErrScoringTimeout),
+			wantState:   string(scoring.StateProviderError),
+			wantMessage: "prediction provider error",
+		},
+		{
+			name:        "unknown error",
+			err:         fmt.Errorf("unexpected provider failure"),
+			wantState:   string(scoring.StateProviderError),
+			wantMessage: "prediction provider error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotState, gotMessage := provider.ClassifyFallback(tt.err)
+			if gotState != tt.wantState {
+				t.Fatalf("state = %q, want %q", gotState, tt.wantState)
+			}
+			if gotMessage != tt.wantMessage {
+				t.Fatalf("message = %q, want %q", gotMessage, tt.wantMessage)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/build-process-watcher#144: Refactor API fallback classification to provider-owned behavior

Fixes #144

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `npm test -- --runInBand`