### PR TITLE
fix: refactor api fallback policy to provider-owned boundary behavior

### DIFF
--- a/backend/internal/handlers/BUILD.bazel
+++ b/backend/internal/handlers/BUILD.bazel
@@ -20,6 +20,5 @@ go_test(
     embed = [":handlers"],
     deps = [
         "//internal/models",
-        "//pkg/predictor",
     ],
 )

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -17,12 +17,6 @@ import (
 	"github.com/cdsap/build-process-watcher/backend/pkg/predictor"
 )
 
-// fallbackClassifier is an optional provider capability for scoring-domain
-// fallback telemetry. Providers that own sentinel errors should implement it.
-type fallbackClassifier interface {
-	ClassifyFallback(err error) (state string, message string)
-}
-
 // Handlers contains all HTTP handlers
 type Handlers struct {
 	storage              *storage.Client
@@ -265,13 +259,7 @@ func (h *Handlers) evaluatePredictionCheckpoints(ctx context.Context, runID stri
 			Now:                   time.Now(),
 		}, checkpointWindow)
 		if err != nil {
-			fallbackState, fallbackMessage := classifyFallback(h.predictor, err)
-			checkpoint = models.PredictionCheckpoint{
-				ObservationWindowS: checkpointWindow,
-				Status:             fallbackState,
-				CreatedAt:          time.Now(),
-				Message:            fallbackMessage,
-			}
+			_, _, _, checkpoint = predictor.FallbackForError(err, checkpointWindow, time.Now())
 			log.Printf("Prediction provider failed for run %s checkpoint %ds: %v", runID, checkpointWindow, err)
 		}
 		if checkpoint.ObservationWindowS == 0 {
@@ -286,15 +274,6 @@ func (h *Handlers) evaluatePredictionCheckpoints(ctx context.Context, runID stri
 		}
 		runDoc.PredictionCheckpoints = storage.MergePredictionCheckpoint(runDoc.PredictionCheckpoints, checkpoint)
 	}
-}
-
-// classifyFallback uses a provider-owned classifier when available, otherwise
-// records a generic provider_error without inspecting scoring sentinel errors.
-func classifyFallback(provider predictor.Provider, err error) (state string, message string) {
-	if classifier, ok := provider.(fallbackClassifier); ok {
-		return classifier.ClassifyFallback(err)
-	}
-	return "provider_error", "prediction provider error"
 }
 
 func boolQuery(r *http.Request, key string) bool {

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -1,15 +1,12 @@
 package handlers
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/cdsap/build-process-watcher/backend/internal/models"
-	"github.com/cdsap/build-process-watcher/backend/pkg/predictor"
 )
 
 func TestIngestHandler_RequestWithProcessInfo(t *testing.T) {
@@ -170,50 +167,5 @@ func TestRunResponse_WithPredictionCheckpoints(t *testing.T) {
 	}
 	if unmarshaled.PredictionCheckpoints[0].ObservationWindowS != 180 {
 		t.Fatalf("Prediction window = %d, want 180", unmarshaled.PredictionCheckpoints[0].ObservationWindowS)
-	}
-}
-
-// classifyingFakeProvider is a predictor.Provider test double that owns fallback
-// telemetry without importing scoring sentinel errors.
-type classifyingFakeProvider struct {
-	state   string
-	message string
-}
-
-func (classifyingFakeProvider) Predict(context.Context, predictor.RunSnapshot, int) (predictor.PredictionCheckpoint, error) {
-	return predictor.PredictionCheckpoint{}, errors.New("synthetic provider failure")
-}
-
-func (p classifyingFakeProvider) ClassifyFallback(error) (string, string) {
-	return p.state, p.message
-}
-
-type plainFakeProvider struct{}
-
-func (plainFakeProvider) Predict(context.Context, predictor.RunSnapshot, int) (predictor.PredictionCheckpoint, error) {
-	return predictor.PredictionCheckpoint{}, errors.New("synthetic provider failure")
-}
-
-func TestClassifyFallbackUsesProviderOwnedClassifier(t *testing.T) {
-	provider := classifyingFakeProvider{
-		state:   "no_data",
-		message: "prediction data unavailable",
-	}
-	state, message := classifyFallback(provider, errors.New("ignored by fake"))
-	if state != "no_data" {
-		t.Fatalf("state = %q, want no_data", state)
-	}
-	if message != "prediction data unavailable" {
-		t.Fatalf("message = %q, want prediction data unavailable", message)
-	}
-}
-
-func TestClassifyFallbackDefaultsWithoutClassifier(t *testing.T) {
-	state, message := classifyFallback(plainFakeProvider{}, errors.New("unexpected"))
-	if state != "provider_error" {
-		t.Fatalf("state = %q, want provider_error", state)
-	}
-	if message != "prediction provider error" {
-		t.Fatalf("message = %q, want prediction provider error", message)
 	}
 }

--- a/backend/pkg/predictor/predictor.go
+++ b/backend/pkg/predictor/predictor.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cdsap/build-process-watcher/backend/internal/models"
+	"github.com/cdsap/build-process-watcher/backend/internal/scoring"
 )
 
 type Sample = models.Sample
@@ -15,6 +16,8 @@ type ProcessInfo = models.ProcessInfo
 type PredictionCheckpoint = models.PredictionCheckpoint
 
 var defaultCheckpoints = []int{60, 300, 600, 1200}
+
+const fallbackModelVersion = "api-fallback"
 
 // RunSnapshot is the public input contract passed to prediction providers.
 type RunSnapshot struct {
@@ -29,6 +32,27 @@ type RunSnapshot struct {
 // Provider returns public-safe checkpoint predictions.
 type Provider interface {
 	Predict(ctx context.Context, snapshot RunSnapshot, observationWindowS int) (PredictionCheckpoint, error)
+}
+
+// FallbackForError maps provider-owned scoring errors to public-safe fallback
+// telemetry fields and a checkpoint safe to persist or return to callers.
+// modelVersion is the fallback telemetry label; it is not written onto the
+// checkpoint so public checkpoint JSON stays free of provider/model fields.
+func FallbackForError(err error, observationWindowS int, now time.Time) (state string, diagnostic string, modelVersion string, checkpoint PredictionCheckpoint) {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	fallbackState, fallbackMessage := scoring.ClassifyFallback(err)
+	state = string(fallbackState)
+	diagnostic = fallbackMessage
+	modelVersion = fallbackModelVersion
+	checkpoint = PredictionCheckpoint{
+		ObservationWindowS: observationWindowS,
+		Status:             state,
+		CreatedAt:          now,
+		Message:            fallbackMessage,
+	}
+	return state, diagnostic, modelVersion, checkpoint
 }
 
 // NoopProvider is the default public provider. It never produces predictions.

--- a/backend/pkg/predictor/predictor_test.go
+++ b/backend/pkg/predictor/predictor_test.go
@@ -2,8 +2,12 @@ package predictor
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/cdsap/build-process-watcher/backend/internal/scoring"
 )
 
 type fakeProvider struct{}
@@ -48,6 +52,95 @@ func TestEnabled(t *testing.T) {
 	}
 	if !Enabled(fakeProvider{}) {
 		t.Fatal("fake provider should be enabled")
+	}
+}
+
+func TestFallbackForErrorMapsSharedScoringTaxonomy(t *testing.T) {
+	now := time.Unix(456, 0).UTC()
+	tests := []struct {
+		name           string
+		err            error
+		wantState      string
+		wantDiagnostic string
+	}{
+		{
+			name:           "no data",
+			err:            fmt.Errorf("provider context: %w", scoring.ErrNoData),
+			wantState:      "no_data",
+			wantDiagnostic: "prediction data unavailable",
+		},
+		{
+			name:           "scoring timeout",
+			err:            fmt.Errorf("provider context: %w", scoring.ErrScoringTimeout),
+			wantState:      "provider_error",
+			wantDiagnostic: "prediction provider error",
+		},
+		{
+			name:           "model unavailable",
+			err:            fmt.Errorf("provider context: %w", scoring.ErrModelUnavailable),
+			wantState:      "model_unavailable",
+			wantDiagnostic: "prediction model unavailable",
+		},
+		{
+			name:           "scoring failed",
+			err:            fmt.Errorf("provider context: %w", scoring.ErrScoringFailed),
+			wantState:      "provider_error",
+			wantDiagnostic: "prediction provider error",
+		},
+		{
+			name:           "unknown error",
+			err:            fmt.Errorf("unexpected provider failure"),
+			wantState:      "provider_error",
+			wantDiagnostic: "prediction provider error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotState, gotDiagnostic, gotModelVersion, checkpoint := FallbackForError(tt.err, 180, now)
+			if gotState != tt.wantState {
+				t.Fatalf("state = %q, want %q", gotState, tt.wantState)
+			}
+			if gotDiagnostic != tt.wantDiagnostic {
+				t.Fatalf("diagnostic = %q, want %q", gotDiagnostic, tt.wantDiagnostic)
+			}
+			if gotModelVersion != "api-fallback" {
+				t.Fatalf("modelVersion = %q, want api-fallback", gotModelVersion)
+			}
+			if checkpoint.ObservationWindowS != 180 {
+				t.Fatalf("ObservationWindowS = %d, want 180", checkpoint.ObservationWindowS)
+			}
+			if checkpoint.Status != tt.wantState {
+				t.Fatalf("Status = %q, want %q", checkpoint.Status, tt.wantState)
+			}
+			if checkpoint.ModelVersion != "" {
+				t.Fatalf("checkpoint ModelVersion = %q, want empty", checkpoint.ModelVersion)
+			}
+			if checkpoint.Message != tt.wantDiagnostic {
+				t.Fatalf("Message = %q, want %q", checkpoint.Message, tt.wantDiagnostic)
+			}
+			if !checkpoint.CreatedAt.Equal(now) {
+				t.Fatalf("CreatedAt = %v, want %v", checkpoint.CreatedAt, now)
+			}
+			if checkpoint.ProviderID != "" {
+				t.Fatalf("ProviderID = %q, want empty fallback provider", checkpoint.ProviderID)
+			}
+		})
+	}
+}
+
+func TestFallbackForErrorDoesNotLeakPrivateDiagnosticToCheckpoint(t *testing.T) {
+	err := fmt.Errorf("private stack: customer id 123: %w", scoring.ErrScoringFailed)
+	_, diagnostic, _, checkpoint := FallbackForError(err, 60, time.Unix(789, 0).UTC())
+
+	if checkpoint.Message != "prediction provider error" {
+		t.Fatalf("Message = %q, want prediction provider error", checkpoint.Message)
+	}
+	if diagnostic != checkpoint.Message {
+		t.Fatalf("diagnostic = %q, want checkpoint message %q", diagnostic, checkpoint.Message)
+	}
+	if checkpoint.Message == err.Error() || strings.Contains(checkpoint.Message, "customer id") {
+		t.Fatal("fallback checkpoint leaked provider diagnostic text")
 	}
 }
 

--- a/backend/pkg/predictor/remote.go
+++ b/backend/pkg/predictor/remote.go
@@ -106,13 +106,6 @@ func (p *RemoteProvider) Predict(ctx context.Context, snapshot RunSnapshot, obse
 	return response.Checkpoint, nil
 }
 
-// ClassifyFallback maps remote scoring failures onto public-safe telemetry.
-// Handlers prefer this optional method over generic provider_error defaults.
-func (*RemoteProvider) ClassifyFallback(err error) (state string, message string) {
-	fallbackState, fallbackMessage := scoring.ClassifyFallback(err)
-	return string(fallbackState), fallbackMessage
-}
-
 type scoringError struct {
 	kind    error
 	message string

--- a/backend/pkg/predictor/remote_test.go
+++ b/backend/pkg/predictor/remote_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -126,59 +125,6 @@ func TestRemoteProviderClassifiesSharedScoringErrors(t *testing.T) {
 			}
 			if !errors.Is(err, tt.want) {
 				t.Fatalf("error = %v, want sentinel %v", err, tt.want)
-			}
-		})
-	}
-}
-
-func TestRemoteProviderClassifyFallbackMapsSharedTaxonomy(t *testing.T) {
-	provider := &RemoteProvider{}
-	tests := []struct {
-		name        string
-		err         error
-		wantState   string
-		wantMessage string
-	}{
-		{
-			name:        "no data",
-			err:         fmt.Errorf("provider context: %w", scoring.ErrNoData),
-			wantState:   string(scoring.StateNoData),
-			wantMessage: "prediction data unavailable",
-		},
-		{
-			name:        "model unavailable",
-			err:         fmt.Errorf("provider context: %w", scoring.ErrModelUnavailable),
-			wantState:   string(scoring.StateModelUnavailable),
-			wantMessage: "prediction model unavailable",
-		},
-		{
-			name:        "scoring failed",
-			err:         fmt.Errorf("provider context: %w", scoring.ErrScoringFailed),
-			wantState:   string(scoring.StateProviderError),
-			wantMessage: "prediction provider error",
-		},
-		{
-			name:        "scoring timeout",
-			err:         fmt.Errorf("provider context: %w", scoring.ErrScoringTimeout),
-			wantState:   string(scoring.StateProviderError),
-			wantMessage: "prediction provider error",
-		},
-		{
-			name:        "unknown error",
-			err:         fmt.Errorf("unexpected provider failure"),
-			wantState:   string(scoring.StateProviderError),
-			wantMessage: "prediction provider error",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotState, gotMessage := provider.ClassifyFallback(tt.err)
-			if gotState != tt.wantState {
-				t.Fatalf("state = %q, want %q", gotState, tt.wantState)
-			}
-			if gotMessage != tt.wantMessage {
-				t.Fatalf("message = %q, want %q", gotMessage, tt.wantMessage)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/build-process-watcher#146: Refactor API fallback policy to provider-owned boundary behavior

Fixes #146

## Agent routing

- Selected agent: `cursor`
- Routing reason: `sufficient_codex_capacity`
- Complexity: `large`

## Verification

- `npm test -- --runInBand`