### PR TITLE
fix: refactor api fallback classification to decouple transport from pro

### DIFF
--- a/backend/BUILD.bazel
+++ b/backend/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
     importpath = "github.com/cdsap/build-process-watcher/backend",
     visibility = ["//visibility:private"],
     deps = [
-        "//pkg/predictor",
+        "//internal/scoring",
         "//pkg/server",
     ],
 )
@@ -27,6 +27,7 @@ go_test(
         "export_test.go",
         "integration_test.go",
         "main_test.go",
+        "prediction_fallback_test.go",
     ],
     embed = [":backend_lib"],
     deps = [
@@ -34,6 +35,7 @@ go_test(
         "//internal/cleanup",
         "//internal/handlers",
         "//internal/models",
+        "//internal/scoring",
         "//internal/storage",
     ],
 )

--- a/backend/internal/handlers/BUILD.bazel
+++ b/backend/internal/handlers/BUILD.bazel
@@ -20,5 +20,6 @@ go_test(
     embed = [":handlers"],
     deps = [
         "//internal/models",
+        "//pkg/predictor",
     ],
 )

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -23,23 +23,29 @@ type Handlers struct {
 	export               *exportqueue.Scheduler
 	predictor            predictor.Provider
 	predictorCheckpoints []int
+	fallbackClassifier   predictor.FallbackClassifier
 }
 
 // NewHandlers creates a new handlers instance. export may be nil (no BigQuery jobs).
 func NewHandlers(storageClient *storage.Client, export *exportqueue.Scheduler) *Handlers {
-	return NewHandlersWithPredictor(storageClient, export, predictor.NoopProvider{}, nil)
+	return NewHandlersWithPredictor(storageClient, export, predictor.NoopProvider{}, nil, nil)
 }
 
-// NewHandlersWithPredictor creates handlers with an optional prediction provider.
-func NewHandlersWithPredictor(storageClient *storage.Client, export *exportqueue.Scheduler, predictionProvider predictor.Provider, checkpoints []int) *Handlers {
+// NewHandlersWithPredictor creates handlers with an optional prediction provider
+// and optional fallback classifier supplied by the composition root.
+func NewHandlersWithPredictor(storageClient *storage.Client, export *exportqueue.Scheduler, predictionProvider predictor.Provider, checkpoints []int, fallbackClassifier predictor.FallbackClassifier) *Handlers {
 	if predictionProvider == nil {
 		predictionProvider = predictor.NoopProvider{}
+	}
+	if fallbackClassifier == nil {
+		fallbackClassifier = predictor.DefaultFallbackClassifier
 	}
 	return &Handlers{
 		storage:              storageClient,
 		export:               export,
 		predictor:            predictionProvider,
 		predictorCheckpoints: checkpoints,
+		fallbackClassifier:   fallbackClassifier,
 	}
 }
 
@@ -259,7 +265,7 @@ func (h *Handlers) evaluatePredictionCheckpoints(ctx context.Context, runID stri
 			Now:                   time.Now(),
 		}, checkpointWindow)
 		if err != nil {
-			_, _, _, checkpoint = predictor.FallbackForError(err, checkpointWindow, time.Now())
+			_, _, _, checkpoint = predictor.FallbackForError(err, checkpointWindow, time.Now(), h.fallbackClassifier)
 			log.Printf("Prediction provider failed for run %s checkpoint %ds: %v", runID, checkpointWindow, err)
 		}
 		if checkpoint.ObservationWindowS == 0 {

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -2,11 +2,15 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cdsap/build-process-watcher/backend/internal/models"
+	"github.com/cdsap/build-process-watcher/backend/pkg/predictor"
 )
 
 func TestIngestHandler_RequestWithProcessInfo(t *testing.T) {
@@ -167,5 +171,27 @@ func TestRunResponse_WithPredictionCheckpoints(t *testing.T) {
 	}
 	if unmarshaled.PredictionCheckpoints[0].ObservationWindowS != 180 {
 		t.Fatalf("Prediction window = %d, want 180", unmarshaled.PredictionCheckpoints[0].ObservationWindowS)
+	}
+}
+
+func TestNewHandlersWithPredictorUsesInjectedFallbackClassifier(t *testing.T) {
+	h := NewHandlersWithPredictor(nil, nil, predictor.NoopProvider{}, nil, func(error) (string, string) {
+		return "no_data", "prediction data unavailable"
+	})
+	state, message := h.fallbackClassifier(errors.New("ignored"))
+	if state != "no_data" || message != "prediction data unavailable" {
+		t.Fatalf("classifier = (%q, %q), want injected mapping", state, message)
+	}
+}
+
+func TestNewHandlersWithPredictorDefaultsFallbackClassifier(t *testing.T) {
+	h := NewHandlersWithPredictor(nil, nil, nil, nil, nil)
+	err := fmt.Errorf("private stack: customer id 9: boom")
+	state, message := h.fallbackClassifier(err)
+	if state != "provider_error" || message != "prediction provider error" {
+		t.Fatalf("classifier = (%q, %q), want default public-safe mapping", state, message)
+	}
+	if strings.Contains(message, "customer id") || message == err.Error() {
+		t.Fatal("default fallback classifier leaked private diagnostic text")
 	}
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -4,12 +4,21 @@ import (
 	"context"
 	"log"
 
+	"github.com/cdsap/build-process-watcher/backend/internal/scoring"
 	"github.com/cdsap/build-process-watcher/backend/pkg/server"
 )
 
 func main() {
 	options := server.OptionsFromEnv()
+	// Wire scoring sentinel classification at the composition root so the HTTP
+	// adapter stays free of concrete provider/scoring error imports.
+	options.FallbackClassifier = predictionFallbackClassifier
 	if err := server.Run(context.Background(), options); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
+}
+
+func predictionFallbackClassifier(err error) (state string, message string) {
+	fallbackState, fallbackMessage := scoring.ClassifyFallback(err)
+	return string(fallbackState), fallbackMessage
 }

--- a/backend/pkg/predictor/predictor.go
+++ b/backend/pkg/predictor/predictor.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/cdsap/build-process-watcher/backend/internal/models"
-	"github.com/cdsap/build-process-watcher/backend/internal/scoring"
 )
 
 type Sample = models.Sample
@@ -18,6 +17,17 @@ type PredictionCheckpoint = models.PredictionCheckpoint
 var defaultCheckpoints = []int{60, 300, 600, 1200}
 
 const fallbackModelVersion = "api-fallback"
+
+// FallbackClassifier maps a provider failure onto a public-safe telemetry state
+// and checkpoint message. Composition roots supply provider-specific mapping;
+// the predictor package itself stays free of concrete scoring sentinel imports.
+type FallbackClassifier func(err error) (state string, message string)
+
+// DefaultFallbackClassifier returns a generic public-safe provider_error without
+// inspecting provider-owned sentinel errors.
+func DefaultFallbackClassifier(error) (state string, message string) {
+	return "provider_error", "prediction provider error"
+}
 
 // RunSnapshot is the public input contract passed to prediction providers.
 type RunSnapshot struct {
@@ -34,23 +44,26 @@ type Provider interface {
 	Predict(ctx context.Context, snapshot RunSnapshot, observationWindowS int) (PredictionCheckpoint, error)
 }
 
-// FallbackForError maps provider-owned scoring errors to public-safe fallback
-// telemetry fields and a checkpoint safe to persist or return to callers.
+// FallbackForError maps a provider failure to public-safe fallback telemetry
+// fields and a checkpoint safe to persist or return to callers.
+// classify carries provider-specific sentinel mapping from the composition root;
+// a nil classifier uses DefaultFallbackClassifier.
 // modelVersion is the fallback telemetry label; it is not written onto the
 // checkpoint so public checkpoint JSON stays free of provider/model fields.
-func FallbackForError(err error, observationWindowS int, now time.Time) (state string, diagnostic string, modelVersion string, checkpoint PredictionCheckpoint) {
+func FallbackForError(err error, observationWindowS int, now time.Time, classify FallbackClassifier) (state string, diagnostic string, modelVersion string, checkpoint PredictionCheckpoint) {
 	if now.IsZero() {
 		now = time.Now()
 	}
-	fallbackState, fallbackMessage := scoring.ClassifyFallback(err)
-	state = string(fallbackState)
-	diagnostic = fallbackMessage
+	if classify == nil {
+		classify = DefaultFallbackClassifier
+	}
+	state, diagnostic = classify(err)
 	modelVersion = fallbackModelVersion
 	checkpoint = PredictionCheckpoint{
 		ObservationWindowS: observationWindowS,
 		Status:             state,
 		CreatedAt:          now,
-		Message:            fallbackMessage,
+		Message:            diagnostic,
 	}
 	return state, diagnostic, modelVersion, checkpoint
 }

--- a/backend/pkg/predictor/predictor_test.go
+++ b/backend/pkg/predictor/predictor_test.go
@@ -55,6 +55,11 @@ func TestEnabled(t *testing.T) {
 	}
 }
 
+func scoringFallbackClassifier(err error) (string, string) {
+	state, message := scoring.ClassifyFallback(err)
+	return string(state), message
+}
+
 func TestFallbackForErrorMapsSharedScoringTaxonomy(t *testing.T) {
 	now := time.Unix(456, 0).UTC()
 	tests := []struct {
@@ -97,7 +102,7 @@ func TestFallbackForErrorMapsSharedScoringTaxonomy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotState, gotDiagnostic, gotModelVersion, checkpoint := FallbackForError(tt.err, 180, now)
+			gotState, gotDiagnostic, gotModelVersion, checkpoint := FallbackForError(tt.err, 180, now, scoringFallbackClassifier)
 			if gotState != tt.wantState {
 				t.Fatalf("state = %q, want %q", gotState, tt.wantState)
 			}
@@ -131,7 +136,7 @@ func TestFallbackForErrorMapsSharedScoringTaxonomy(t *testing.T) {
 
 func TestFallbackForErrorDoesNotLeakPrivateDiagnosticToCheckpoint(t *testing.T) {
 	err := fmt.Errorf("private stack: customer id 123: %w", scoring.ErrScoringFailed)
-	_, diagnostic, _, checkpoint := FallbackForError(err, 60, time.Unix(789, 0).UTC())
+	_, diagnostic, _, checkpoint := FallbackForError(err, 60, time.Unix(789, 0).UTC(), scoringFallbackClassifier)
 
 	if checkpoint.Message != "prediction provider error" {
 		t.Fatalf("Message = %q, want prediction provider error", checkpoint.Message)
@@ -141,6 +146,34 @@ func TestFallbackForErrorDoesNotLeakPrivateDiagnosticToCheckpoint(t *testing.T) 
 	}
 	if checkpoint.Message == err.Error() || strings.Contains(checkpoint.Message, "customer id") {
 		t.Fatal("fallback checkpoint leaked provider diagnostic text")
+	}
+}
+
+func TestFallbackForErrorUsesDefaultClassifierWhenNil(t *testing.T) {
+	err := fmt.Errorf("provider context: %w", scoring.ErrNoData)
+	state, diagnostic, _, checkpoint := FallbackForError(err, 60, time.Unix(1, 0).UTC(), nil)
+
+	if state != "provider_error" {
+		t.Fatalf("state = %q, want provider_error without injected classifier", state)
+	}
+	if diagnostic != "prediction provider error" {
+		t.Fatalf("diagnostic = %q, want prediction provider error", diagnostic)
+	}
+	if checkpoint.Message != diagnostic || checkpoint.Status != state {
+		t.Fatalf("checkpoint = %+v, want status/message matching default classifier", checkpoint)
+	}
+	if strings.Contains(checkpoint.Message, "no data") || strings.Contains(checkpoint.Message, err.Error()) {
+		t.Fatal("default fallback leaked scoring-specific or private diagnostic text")
+	}
+}
+
+func TestDefaultFallbackClassifierIsPublicSafe(t *testing.T) {
+	state, message := DefaultFallbackClassifier(fmt.Errorf("private stack: customer id 123: %w", scoring.ErrModelUnavailable))
+	if state != "provider_error" {
+		t.Fatalf("state = %q, want provider_error", state)
+	}
+	if message != "prediction provider error" {
+		t.Fatalf("message = %q, want prediction provider error", message)
 	}
 }
 

--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -28,6 +28,10 @@ type Options struct {
 	BigQueryProcessesTable string
 	PredictionProvider     predictor.Provider
 	PredictionCheckpoints  []int
+	// FallbackClassifier maps provider failures onto public-safe telemetry.
+	// Composition roots (for example backend main) supply provider-specific
+	// sentinel mapping; nil uses predictor.DefaultFallbackClassifier.
+	FallbackClassifier predictor.FallbackClassifier
 }
 
 // OptionsFromEnv reads public backend configuration from environment variables.
@@ -101,7 +105,7 @@ func Run(ctx context.Context, options Options) error {
 		log.Printf("🔮 Predictive reliability disabled (set private provider and PREDICTIVE_RELIABILITY_CHECKPOINTS to enable)")
 	}
 
-	h := handlers.NewHandlersWithPredictor(storageClient, exportSched, provider, options.PredictionCheckpoints)
+	h := handlers.NewHandlersWithPredictor(storageClient, exportSched, provider, options.PredictionCheckpoints, options.FallbackClassifier)
 	cleanupService := cleanup.NewService(storageClient, exportSched)
 	mux := NewMux(h, cleanupService)
 	port := portOrDefault(options.Port)

--- a/backend/pkg/server/server_test.go
+++ b/backend/pkg/server/server_test.go
@@ -148,6 +148,29 @@ func TestOptionsCanCarryInjectedProvider(t *testing.T) {
 	}
 }
 
+func TestOptionsCanCarryFallbackClassifier(t *testing.T) {
+	options := Options{
+		FallbackClassifier: func(error) (string, string) {
+			return "no_data", "prediction data unavailable"
+		},
+	}
+	if options.FallbackClassifier == nil {
+		t.Fatal("FallbackClassifier should be injectable on Options")
+	}
+	state, message := options.FallbackClassifier(nil)
+	if state != "no_data" || message != "prediction data unavailable" {
+		t.Fatalf("classifier = (%q, %q), want no_data / prediction data unavailable", state, message)
+	}
+}
+
+func TestOptionsFromEnvLeavesFallbackClassifierUnset(t *testing.T) {
+	t.Setenv("PREDICTIVE_PROVIDER_ENABLED", "false")
+	options := OptionsFromEnv()
+	if options.FallbackClassifier != nil {
+		t.Fatal("OptionsFromEnv should leave FallbackClassifier unset for composition-root wiring")
+	}
+}
+
 func TestNewMuxRegistersPublicRoutes(t *testing.T) {
 	mux := NewMux(handlers.NewHandlers(nil, nil), cleanup.NewService(nil, nil))
 

--- a/backend/prediction_fallback_test.go
+++ b/backend/prediction_fallback_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cdsap/build-process-watcher/backend/internal/scoring"
+)
+
+func TestPredictionFallbackClassifierMapsScoringTaxonomyWithoutLeaking(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantState   string
+		wantMessage string
+	}{
+		{
+			name:        "no data",
+			err:         fmt.Errorf("provider context: %w", scoring.ErrNoData),
+			wantState:   "no_data",
+			wantMessage: "prediction data unavailable",
+		},
+		{
+			name:        "model unavailable",
+			err:         fmt.Errorf("provider context: %w", scoring.ErrModelUnavailable),
+			wantState:   "model_unavailable",
+			wantMessage: "prediction model unavailable",
+		},
+		{
+			name:        "scoring failed",
+			err:         fmt.Errorf("private stack: customer id 123: %w", scoring.ErrScoringFailed),
+			wantState:   "provider_error",
+			wantMessage: "prediction provider error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, message := predictionFallbackClassifier(tt.err)
+			if state != tt.wantState {
+				t.Fatalf("state = %q, want %q", state, tt.wantState)
+			}
+			if message != tt.wantMessage {
+				t.Fatalf("message = %q, want %q", message, tt.wantMessage)
+			}
+			if message == tt.err.Error() || strings.Contains(message, "customer id") {
+				t.Fatal("startup classifier leaked private diagnostic text")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/build-process-watcher#153: Refactor API fallback classification to decouple transport from provider implementation

Fixes #153

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `npm test -- --runInBand`