### PR TITLE
docs: allow TheTester to dispatch remote validation workflows

### DIFF
--- a/docs/testing/the-tester.md
+++ b/docs/testing/the-tester.md
@@ -12,12 +12,20 @@ TheTester must validate observable user behavior, not only process exit codes.
 ## Safety
 
 Prefer existing recent GitHub Actions runs when they satisfy the scenario under
-test. Trigger a new workflow run only when the user explicitly asks for a fresh
-run or the current acceptance criteria require fresh build identifiers.
+test.
+
+TheTester is authorized to dispatch GitHub Actions workflows for this repository
+when no suitable current-commit run exists for a required remote scenario.
+Allowed dispatches include `test-action.yml`, `test-e2e-action.yml`, and
+`predictive-contract-smoke.yml` (and equivalent Process Action / predictive
+smoke workflows). Prefer `workflow_dispatch` on the commit or ref under test.
+Wait for the dispatched run to finish and use its URLs, artifacts, and dashboard
+links as evidence.
 
 Do not merge changes, publish releases, delete remote data, or modify production
-configuration. If remote credentials, workflow permissions, or Firebase access
-are unavailable, report `BLOCKED` with the missing dependency and the evidence.
+configuration. Do not dispatch deploy workflows. If remote credentials, workflow
+permissions, or Firebase access are unavailable, report `BLOCKED` with the
+missing dependency and the evidence.
 
 When a scenario uses remote data, retain the GitHub Actions run URL, dashboard
 run URL, compare URL, replay URL, build identifiers, screenshots, and relevant


### PR DESCRIPTION
## Summary
- Authorize TheTester to `workflow_dispatch` Process Action / predictive smoke workflows when no current-commit remote run satisfies Scenarios 2–3.
- Keep preferring existing runs first; still forbid merge/release/deploy and production changes.

## Test plan
- [ ] Confirm `docs/testing/the-tester.md` Safety section explicitly allows dispatch for TheTester.
- [ ] Next TheTester Runner on `cdsap/build-process-watcher` should dispatch rather than report `BLOCKED` for missing remote runs (when credentials/permissions are available).


Made with [Cursor](https://cursor.com)