### PR TITLE
fix: refactor handler bearer auth to a shared verifier

### DIFF
--- a/backend/internal/handlers/BUILD.bazel
+++ b/backend/internal/handlers/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
     srcs = ["handlers_test.go"],
     embed = [":handlers"],
     deps = [
+        "//internal/auth",
         "//internal/models",
         "//pkg/predictor",
     ],

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -49,6 +49,36 @@ func NewHandlersWithPredictor(storageClient *storage.Client, export *exportqueue
 	}
 }
 
+// validateRunBearerToken verifies the Authorization Bearer token for a run write.
+// Callers write the HTTP response using the returned status and message when ok is false.
+func validateRunBearerToken(r *http.Request, runID string) (status int, message string, ok bool) {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		log.Printf("No authorization header provided for run_id: %s from %s", runID, r.RemoteAddr)
+		return http.StatusUnauthorized, "Authorization header required", false
+	}
+
+	tokenParts := strings.Split(authHeader, " ")
+	if len(tokenParts) != 2 || tokenParts[0] != "Bearer" {
+		log.Printf("Invalid authorization header format for run_id: %s from %s", runID, r.RemoteAddr)
+		return http.StatusUnauthorized, "Invalid authorization header format", false
+	}
+
+	token := tokenParts[1]
+	valid, err := auth.ValidateToken(token, runID)
+	if err != nil {
+		log.Printf("Token validation failed for run_id: %s: %v", runID, err)
+		return http.StatusUnauthorized, "Token validation failed", false
+	}
+
+	if !valid {
+		log.Printf("Invalid token for run_id: %s from %s", runID, r.RemoteAddr)
+		return http.StatusUnauthorized, "Invalid token", false
+	}
+
+	return 0, "", true
+}
+
 // Health returns a simple health check
 func (h *Handlers) Health(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
@@ -128,33 +158,8 @@ func (h *Handlers) Ingest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify token
-	authHeader := r.Header.Get("Authorization")
-	if authHeader == "" {
-		log.Printf("No authorization header provided")
-		http.Error(w, "Authorization header required", http.StatusUnauthorized)
-		return
-	}
-
-	// Extract token from "Bearer <token>"
-	tokenParts := strings.Split(authHeader, " ")
-	if len(tokenParts) != 2 || tokenParts[0] != "Bearer" {
-		log.Printf("Invalid authorization header format")
-		http.Error(w, "Invalid authorization header format", http.StatusUnauthorized)
-		return
-	}
-
-	token := tokenParts[1]
-	valid, err := auth.ValidateToken(token, req.RunID)
-	if err != nil {
-		log.Printf("Token validation failed: %v", err)
-		http.Error(w, "Token validation failed", http.StatusUnauthorized)
-		return
-	}
-
-	if !valid {
-		log.Printf("Invalid token for run_id: %s", req.RunID)
-		http.Error(w, "Invalid token", http.StatusUnauthorized)
+	if status, message, ok := validateRunBearerToken(r, req.RunID); !ok {
+		http.Error(w, message, status)
 		return
 	}
 
@@ -399,33 +404,8 @@ func (h *Handlers) FinishRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify JWT token
-	authHeader := r.Header.Get("Authorization")
-	if authHeader == "" {
-		log.Printf("⚠️  Finish request without authorization from %s for run: %s", r.RemoteAddr, runID)
-		http.Error(w, "Authorization header required", http.StatusUnauthorized)
-		return
-	}
-
-	// Extract token from "Bearer <token>"
-	tokenParts := strings.Split(authHeader, " ")
-	if len(tokenParts) != 2 || tokenParts[0] != "Bearer" {
-		log.Printf("⚠️  Invalid authorization header format from %s", r.RemoteAddr)
-		http.Error(w, "Invalid authorization header format", http.StatusUnauthorized)
-		return
-	}
-
-	token := tokenParts[1]
-	valid, err := auth.ValidateToken(token, runID)
-	if err != nil {
-		log.Printf("⚠️  Token validation failed for run %s: %v", runID, err)
-		http.Error(w, "Token validation failed", http.StatusUnauthorized)
-		return
-	}
-
-	if !valid {
-		log.Printf("⚠️  Invalid token for run %s from %s", runID, r.RemoteAddr)
-		http.Error(w, "Invalid token", http.StatusUnauthorized)
+	if status, message, ok := validateRunBearerToken(r, runID); !ok {
+		http.Error(w, message, status)
 		return
 	}
 

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -4,14 +4,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/cdsap/build-process-watcher/backend/internal/auth"
 	"github.com/cdsap/build-process-watcher/backend/internal/models"
 	"github.com/cdsap/build-process-watcher/backend/pkg/predictor"
 )
+
+func TestMain(m *testing.M) {
+	auth.Initialize()
+	os.Exit(m.Run())
+}
 
 func TestIngestHandler_RequestWithProcessInfo(t *testing.T) {
 	// Test that IngestRequest with ProcessInfo can be properly parsed
@@ -193,5 +201,82 @@ func TestNewHandlersWithPredictorDefaultsFallbackClassifier(t *testing.T) {
 	}
 	if strings.Contains(message, "customer id") || message == err.Error() {
 		t.Fatal("default fallback classifier leaked private diagnostic text")
+	}
+}
+
+func TestValidateRunBearerToken(t *testing.T) {
+	const runID = "run-bearer-auth-1"
+
+	validToken, _, err := auth.GenerateToken(runID)
+	if err != nil {
+		t.Fatalf("GenerateToken failed: %v", err)
+	}
+	otherToken, _, err := auth.GenerateToken("other-run")
+	if err != nil {
+		t.Fatalf("GenerateToken for other run failed: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		header     string
+		wantStatus int
+		wantMsg    string
+		wantOK     bool
+	}{
+		{
+			name:       "missing authorization header",
+			header:     "",
+			wantStatus: http.StatusUnauthorized,
+			wantMsg:    "Authorization header required",
+		},
+		{
+			name:       "invalid authorization header format",
+			header:     "Token " + validToken,
+			wantStatus: http.StatusUnauthorized,
+			wantMsg:    "Invalid authorization header format",
+		},
+		{
+			name:       "invalid token",
+			header:     "Bearer not-a-valid-token",
+			wantStatus: http.StatusUnauthorized,
+			wantMsg:    "Token validation failed",
+		},
+		{
+			name:       "mismatched run id",
+			header:     "Bearer " + otherToken,
+			wantStatus: http.StatusUnauthorized,
+			wantMsg:    "Token validation failed",
+		},
+		{
+			name:   "valid bearer token",
+			header: "Bearer " + validToken,
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/ingest", nil)
+			if tt.header != "" {
+				req.Header.Set("Authorization", tt.header)
+			}
+
+			status, message, ok := validateRunBearerToken(req, runID)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (status=%d message=%q)", ok, tt.wantOK, status, message)
+			}
+			if tt.wantOK {
+				if status != 0 || message != "" {
+					t.Fatalf("status/message = (%d, %q), want zero values on success", status, message)
+				}
+				return
+			}
+			if status != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", status, tt.wantStatus)
+			}
+			if message != tt.wantMsg {
+				t.Fatalf("message = %q, want %q", message, tt.wantMsg)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

### Problem

backend/internal/handlers/handlers.go duplicates Authorization header parsing and auth.ValidateToken handling in Ingest at lines 131-159 and FinishRun at lines 402-430. The two blocks perform the same transport/auth boundary work with slightly different log messages and response paths.

### Why this matters

Duplicated JWT request handling makes future auth behavior changes easy to apply in one handler but miss in the other, especially as ingest and finish remain separate write endpoints for the same run aggregate.

### Proposed change

Extract a small unexported helper in backend/internal/handlers/handlers.go, for example validateRunBearerToken(r *http.Request, runID string) (status int, message string, ok bool), and have Ingest and FinishRun call it before continuing. Keep HTTP response writing in the handlers so behavior and status codes remain unchanged.

### Notes

Clean architecture lens: this keeps endpoint orchestration in handlers while making the run-write authorization policy a single local boundary helper, improving testability without introducing a new package or broader auth redesign.

Fixes #159

## Changes

- `backend/internal/handlers/BUILD.bazel`
- `backend/internal/handlers/handlers.go`
- `backend/internal/handlers/handlers_test.go`

## Verification

- `npm test -- --runInBand`
