### PR TITLE
fix: refactor action runtime paths to clarify startup state boundary

### DIFF
--- a/__tests__/index-with-backend-flags.test.ts
+++ b/__tests__/index-with-backend-flags.test.ts
@@ -1,8 +1,93 @@
+import * as path from 'path';
 import {
   DEFAULT_BACKEND_URL,
   DEFAULT_FRONTEND_BASE_URL,
+  DEFAULT_LOG_FILE_NAME,
+  resolveActionRuntimePaths,
   resolveMonitoringFeatureFlags,
 } from '../src/monitoring_features';
+
+describe('resolveActionRuntimePaths', () => {
+  const runId = 'run-abc';
+  const runnerTempRoot = '/tmp/runner';
+  const workspaceDir = '/workspace/project';
+
+  it('places the default log file under RUNNER_TEMP/build-process-watcher/<runId>', () => {
+    const result = resolveActionRuntimePaths({
+      runId,
+      logFileInput: DEFAULT_LOG_FILE_NAME,
+      workspaceDir,
+      runnerTempRoot,
+      logFileExists: () => false,
+    });
+
+    expect(result).toEqual({
+      runnerTempDir: path.join(runnerTempRoot, 'build-process-watcher', runId),
+      logFilePath: path.join(runnerTempRoot, 'build-process-watcher', runId, DEFAULT_LOG_FILE_NAME),
+      defaultLogFile: true,
+    });
+  });
+
+  it('suffixes the default log file with the run id when that path already exists', () => {
+    const defaultPath = path.join(
+      runnerTempRoot,
+      'build-process-watcher',
+      runId,
+      DEFAULT_LOG_FILE_NAME
+    );
+    const result = resolveActionRuntimePaths({
+      runId,
+      logFileInput: DEFAULT_LOG_FILE_NAME,
+      workspaceDir,
+      runnerTempRoot,
+      logFileExists: (candidatePath) => candidatePath === defaultPath,
+    });
+
+    expect(result).toEqual({
+      runnerTempDir: path.join(runnerTempRoot, 'build-process-watcher', runId),
+      logFilePath: path.join(
+        runnerTempRoot,
+        'build-process-watcher',
+        runId,
+        `build_process_watcher-${runId}.log`
+      ),
+      defaultLogFile: true,
+    });
+  });
+
+  it('resolves a workspace-relative custom log path against GITHUB_WORKSPACE', () => {
+    const result = resolveActionRuntimePaths({
+      runId,
+      logFileInput: 'logs/custom.log',
+      workspaceDir,
+      runnerTempRoot,
+      logFileExists: () => true,
+    });
+
+    expect(result).toEqual({
+      runnerTempDir: path.join(runnerTempRoot, 'build-process-watcher', runId),
+      logFilePath: path.join(workspaceDir, 'logs/custom.log'),
+      defaultLogFile: false,
+    });
+  });
+
+  it('preserves an absolute custom log path', () => {
+    const absoluteLog = '/var/log/bpw/custom.log';
+    const result = resolveActionRuntimePaths({
+      runId,
+      logFileInput: absoluteLog,
+      workspaceDir,
+      runnerTempRoot,
+      logFileExists: () => true,
+    });
+
+    expect(result).toEqual({
+      runnerTempDir: path.join(runnerTempRoot, 'build-process-watcher', runId),
+      logFilePath: absoluteLog,
+      defaultLogFile: false,
+    });
+  });
+});
 
 describe('resolveMonitoringFeatureFlags', () => {
   it('keeps local mode when no remote-only feature is requested', () => {

--- a/src/index_with_backend.ts
+++ b/src/index_with_backend.ts
@@ -4,7 +4,11 @@ import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { resolveMonitoringFeatureFlags } from './monitoring_features';
+import {
+  DEFAULT_LOG_FILE_NAME,
+  resolveActionRuntimePaths,
+  resolveMonitoringFeatureFlags,
+} from './monitoring_features';
 
 async function run() {
   try {
@@ -13,23 +17,23 @@ async function run() {
     const remoteMonitoringRequested = core.getInput('remote_monitoring') === 'true';
     const runId = core.getInput('run_id') || `run-${Date.now()}`;
     const debugMode = core.getInput('debug') === 'true';
-    const logFileInput = core.getInput('log_file') || 'build_process_watcher.log';
+    const logFileInput = core.getInput('log_file') || DEFAULT_LOG_FILE_NAME;
     const workspaceDir = process.env.GITHUB_WORKSPACE;
     const runnerTempRoot = process.env.RUNNER_TEMP || os.tmpdir();
-    const runnerTempDir = path.join(runnerTempRoot, 'build-process-watcher', runId);
+    const { runnerTempDir, logFilePath, defaultLogFile } = resolveActionRuntimePaths({
+      runId,
+      logFileInput,
+      workspaceDir,
+      runnerTempRoot,
+      logFileExists: fs.existsSync,
+    });
     fs.mkdirSync(runnerTempDir, { recursive: true });
-    const defaultLogFile = logFileInput === 'build_process_watcher.log';
-    let logFilePath = defaultLogFile
-      ? path.join(runnerTempDir, logFileInput)
-      : !path.isAbsolute(logFileInput) && workspaceDir
-        ? path.join(workspaceDir, logFileInput)
-        : logFileInput;
-    if (logFileInput === 'build_process_watcher.log' && fs.existsSync(logFilePath)) {
-      const logDir = path.dirname(logFilePath);
-      logFilePath = path.join(logDir, `build_process_watcher-${runId}.log`);
-      if (debugMode) {
-        core.info(`🧭 Log file already exists, using: ${logFilePath}`);
-      }
+    if (
+      debugMode &&
+      defaultLogFile &&
+      path.basename(logFilePath) === `build_process_watcher-${runId}.log`
+    ) {
+      core.info(`🧭 Log file already exists, using: ${logFilePath}`);
     }
     const interval = core.getInput('interval') || '5';
     const disableSummaryOutput = core.getInput('disable_summary_output') === 'true';

--- a/src/monitoring_features.ts
+++ b/src/monitoring_features.ts
@@ -1,6 +1,9 @@
+import * as path from 'path';
+
 export const DEFAULT_BACKEND_URL =
   'https://build-process-watcher-backend-685615422311.us-central1.run.app';
 export const DEFAULT_FRONTEND_BASE_URL = 'https://process-watcher.web.app';
+export const DEFAULT_LOG_FILE_NAME = 'build_process_watcher.log';
 
 export interface MonitoringFeatureFlags {
   enableBackend: boolean;
@@ -8,6 +11,43 @@ export interface MonitoringFeatureFlags {
   frontendUrl: string;
   exportToBigquery: boolean;
   predictiveReliability: boolean;
+}
+
+export interface ActionRuntimePaths {
+  runnerTempDir: string;
+  logFilePath: string;
+  defaultLogFile: boolean;
+}
+
+export function resolveActionRuntimePaths(inputs: {
+  runId: string;
+  logFileInput: string;
+  workspaceDir?: string;
+  runnerTempRoot: string;
+  logFileExists: (candidatePath: string) => boolean;
+}): ActionRuntimePaths {
+  const runnerTempDir = path.join(
+    inputs.runnerTempRoot,
+    'build-process-watcher',
+    inputs.runId
+  );
+  const defaultLogFile = inputs.logFileInput === DEFAULT_LOG_FILE_NAME;
+  let logFilePath = defaultLogFile
+    ? path.join(runnerTempDir, inputs.logFileInput)
+    : !path.isAbsolute(inputs.logFileInput) && inputs.workspaceDir
+      ? path.join(inputs.workspaceDir, inputs.logFileInput)
+      : inputs.logFileInput;
+
+  if (defaultLogFile && inputs.logFileExists(logFilePath)) {
+    const logDir = path.dirname(logFilePath);
+    logFilePath = path.join(logDir, `build_process_watcher-${inputs.runId}.log`);
+  }
+
+  return {
+    runnerTempDir,
+    logFilePath,
+    defaultLogFile,
+  };
 }
 
 function buildFrontendRunUrl(frontendBaseUrl: string, runId: string): string {


### PR DESCRIPTION
## Summary

### Problem

`src/index_with_backend.ts:16-29` mixes GitHub Actions input handling with runtime path derivation for the per-run temp directory and log file fallback. The same hidden path contract is then consumed by cleanup code that reconstructs paths such as `RUNNER_TEMP/build-process-watcher/<runId>` in `src/cleanup.ts:1037-1049` and `src/cleanup.ts:1074-1081`. Today that contract is embedded in orchestration code rather than named and tested as its own behavior.

### Why this matters

The action start step and cleanup post step must agree on where run metadata, logs, and URL handoff files live. Keeping that convention inline makes future changes to log-file handling or temp-directory layout easy to break without focused tests, especially because cleanup runs later in a different process.

### Proposed change

Extract a small pure helper, for example `resolveActionRuntimePaths`, that takes `runId`, `logFileInput`, `workspaceDir`, `runnerTempRoot`, and a `logFileExists` predicate, then returns `runnerTempDir`, `logFilePath`, and `defaultLogFile`. Have `src/index_with_backend.ts` call the helper while keeping directory creation and file writes in the entrypoint. Add focused Jest coverage for default log placement, collision suffix behavior, workspace-relative custom log paths, and absolute custom log paths.

### Notes

Clean architecture lens: this separates core action runtime-path policy from the GitHub Actions adapter code. It is intentionally small: no schema changes, no cleanup rewrite, and no change to monitoring behavior.

Fixes #161

## Changes

- `__tests__/index-with-backend-flags.test.ts`
- `src/index_with_backend.ts`
- `src/monitoring_features.ts`

## Verification

- `npm test -- --runInBand`
